### PR TITLE
move default excludes into base.yml

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -4,7 +4,15 @@ require:
 AllCops:
   # Prevent RuboCop from exploding when it finds an older-than-2.4 .ruby-version
   TargetRubyVersion: 2.5
-  Exclude: []
+  Exclude:
+  # Match RuboCop's defaults: https://github.com/rubocop-hq/rubocop/blob/v0.61.1/config/default.yml#L60-L63
+  - ".git/**/*"
+  - "node_modules/**/*"
+  - "vendor/**/*"
+  # Standard's own default ignores:
+  - "bin/*"
+  - "db/schema.rb"
+  - "tmp/**/*"
 
 Bundler/DuplicatedGem:
   Enabled: true

--- a/test/standard/builds_config_test.rb
+++ b/test/standard/builds_config_test.rb
@@ -53,7 +53,7 @@ class Standard::BuildsConfigTest < UnitTest
     expected_config = RuboCop::ConfigStore.new.tap do |config_store|
       config_store.options_config = path("config/ruby-1.8.yml")
       options_config = config_store.instance_variable_get("@options_config")
-      options_config["AllCops"]["Exclude"] |= [path("test/fixture/config/y/monkey/**/*")]
+      options_config["AllCops"]["Exclude"] = [path("test/fixture/config/y/monkey/**/*")]
       options_config["Fake/Lol"] = {"Exclude" => [path("test/fixture/config/y/neat/cool.rb")]}
       options_config["Fake/Kek"] = {"Exclude" => [path("test/fixture/config/y/neat/cool.rb")]}
     end.for("").to_h
@@ -133,7 +133,6 @@ class Standard::BuildsConfigTest < UnitTest
       config_store.options_config = path(rubocop_yml)
       options_config = config_store.instance_variable_get("@options_config")
       options_config["AllCops"]["TargetRubyVersion"] = ruby_version.to_f
-      options_config["AllCops"]["Exclude"] |= standard_default_ignores(config_root)
     end.for("").to_h
   end
 
@@ -148,11 +147,5 @@ class Standard::BuildsConfigTest < UnitTest
     else
       "config/base.yml"
     end
-  end
-
-  def standard_default_ignores(config_root)
-    Standard::CreatesConfigStore::ConfiguresIgnoredPaths::DEFAULT_IGNORES.map { |(path, _)|
-      File.expand_path(File.join(config_root || Dir.pwd, path))
-    }
   end
 end

--- a/test/standardrb_test.rb
+++ b/test/standardrb_test.rb
@@ -28,7 +28,6 @@ class StandardrbTest < UnitTest
     assert_same_lines <<-MSG.gsub(/^ {6}/, ""), stdout
       #{standard_greeting}
         do_lint.rb:1:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
-        tmp/do_lint.rb:1:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
     MSG
   end
 


### PR DESCRIPTION
this makes inherit_gem workflow simpler and also makes the config easier to see when spelunking base.yml