### PR TITLE
Support ruby-next versioning

### DIFF
--- a/lib/standard/creates_config_store/assigns_rubocop_yaml.rb
+++ b/lib/standard/creates_config_store/assigns_rubocop_yaml.rb
@@ -10,7 +10,11 @@ class Standard::CreatesConfigStore
     private
 
     def rubocop_yaml_path(desired_version)
-      file_name = if desired_version < Gem::Version.new("1.9")
+      default = "base.yml"
+
+      file_name = if !Gem::Version.correct?(desired_version)
+        default
+      elsif desired_version < Gem::Version.new("1.9")
         "ruby-1.8.yml"
       elsif desired_version < Gem::Version.new("2.0")
         "ruby-1.9.yml"
@@ -25,7 +29,7 @@ class Standard::CreatesConfigStore
       elsif desired_version < Gem::Version.new("3.0")
         "ruby-2.7.yml"
       else
-        "base.yml"
+        default
       end
 
       Pathname.new(__dir__).join("../../../config/#{file_name}")

--- a/lib/standard/creates_config_store/sets_target_ruby_version.rb
+++ b/lib/standard/creates_config_store/sets_target_ruby_version.rb
@@ -1,7 +1,7 @@
 class Standard::CreatesConfigStore
   class SetsTargetRubyVersion
     def call(options_config, standard_config)
-      options_config["AllCops"]["TargetRubyVersion"] = floatify_version(
+      options_config["AllCops"]["TargetRubyVersion"] = normalize_version(
         max_rubocop_supported_version(standard_config[:ruby_version])
       )
     end
@@ -9,6 +9,8 @@ class Standard::CreatesConfigStore
     private
 
     def max_rubocop_supported_version(desired_version)
+      return desired_version unless Gem::Version.correct?(desired_version)
+
       rubocop_supported_version = Gem::Version.new("2.5")
       if desired_version < rubocop_supported_version
         rubocop_supported_version
@@ -17,7 +19,9 @@ class Standard::CreatesConfigStore
       end
     end
 
-    def floatify_version(version)
+    def normalize_version(version)
+      return version unless Gem::Version.correct?(version)
+
       major, minor = version.segments
       "#{major}.#{minor}".to_f # lol
     end

--- a/lib/standard/loads_yaml_config.rb
+++ b/lib/standard/loads_yaml_config.rb
@@ -24,7 +24,7 @@ module Standard
 
     def construct_config(yaml_path, standard_yaml, todo_path, todo_yaml)
       {
-        ruby_version: Gem::Version.new((standard_yaml["ruby_version"] || RUBY_VERSION)),
+        ruby_version: normalized_ruby_version(standard_yaml["ruby_version"]),
         fix: !!standard_yaml["fix"],
         format: standard_yaml["format"],
         parallel: !!standard_yaml["parallel"],
@@ -34,6 +34,12 @@ module Standard
         todo_file: todo_path,
         todo_ignore_files: (todo_yaml["ignore"] || []).map { |f| Hash === f ? f.keys.first : f }
       }
+    end
+
+    def normalized_ruby_version(version)
+      return version unless Gem::Version.correct?(version)
+
+      Gem::Version.new((version || RUBY_VERSION))
     end
 
     def expand_ignore_config(ignore_config)

--- a/test/standard/creates_config_store/sets_target_ruby_version_test.rb
+++ b/test/standard/creates_config_store/sets_target_ruby_version_test.rb
@@ -1,0 +1,39 @@
+require_relative "../../test_helper"
+
+class Standard::SetsTargetRubyVersionTest < UnitTest
+  def setup
+    @subject = Standard::CreatesConfigStore::SetsTargetRubyVersion.new
+  end
+
+  def test_sets_standard_numeric_target_ruby_version
+    options_config = {
+      "AllCops" => {}
+    }
+
+    @subject.call(options_config, {
+      ruby_version: Gem::Version.new("3.0.1")
+    })
+
+    assert_equal({
+      "AllCops" => {
+        "TargetRubyVersion" => 3.0
+      }
+    }, options_config)
+  end
+
+  def test_sets_non_numeric_target_ruby_version
+    options_config = {
+      "AllCops" => {}
+    }
+
+    @subject.call(options_config, {
+      ruby_version: "next"
+    })
+
+    assert_equal({
+      "AllCops" => {
+        "TargetRubyVersion" => "next"
+      }
+    }, options_config)
+  end
+end


### PR DESCRIPTION
The goal of this change was to explore what would be involved in supporting `ruby-next` versioning from https://github.com/testdouble/standard/issues/334.

**Disclaimer**: I had never used `ruby-next` before, so there may need to be a more experienced confirmation beyond the basics I did here.

I'm not sure how much `ruby-next` is used, but my thoughts about this particular issue are more about compatibility with rubocop rather than supporting `ruby-next`. Since standard is a thin-wrapper to prevent bikeshedding with configuring rubocop, a change like this makes sense to me to ensure surprising crashes like this caused are handled better. Any discussion about this is welcome.

The essentials here is that `ruby-next` requires that the `TargetRubyVersion` setting is given a value of `next`, but `standard` used `Gem::Version.new` in a few places which requires a traditional version number. This PR changes that to allow an unconventional target version that isn't as rigid.

## Development Setup with Ruby Next

```yaml
# .rubocop.yml
require: standard

inherit_gem:
  standard: config/base.yml

AllCops:
  DisabledByDefault: true
```

```yaml
# .standard.yml
ruby_version: next
```

```ruby
# Gemfile
source "https://rubygems.org"

git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }

gem "ruby-next"
gem "standard", git: "https://github.com/testdouble/standard.git", branch: "334-support-require-for-ruby-next"
```

```ruby
# main.rb (from the ruby-next README)
require "ruby-next"

using RubyNext

def greet(val) =
  case val
    in hello: hello if hello =~ /human/i
      "🙂"
    in hello: "martian"
      "👽"
    end

puts greet(hello: "martian")
```

- [Ruby Next README](https://github.com/ruby-next/ruby-next)
- [Ruby Next Rubocop Setup](https://github.com/ruby-next/ruby-next#rubocop)

## Questions

- ~I didn't take a TDD approach to experimenting to this solution, so I'm curious as to where I should put the tests for verifying a non-standard version number.~

- It may not be necessary, but do you know why `- ruby-next/rubocop` cannot be added alongside `standard` in `.rubocop.yml` like
```yaml
require:
- standard
- ruby-next/rubocop
```

## Todo

- [ ] Add some documentation once everything is resolved