### PR TITLE
Prevent todo warning for empty file list

### DIFF
--- a/lib/standard/formatter.rb
+++ b/lib/standard/formatter.rb
@@ -87,7 +87,7 @@ module Standard
       return if todo_ignore_files&.any?
 
       output.print <<-HEADER.gsub(/^ {8}/, "")
-        Congrats, you're done! Delete `#{todo_file}` in celebration.
+        Congratulations, you've successfully migrated this project to Standard! Delete `#{todo_file}` in celebration.
       HEADER
     end
 

--- a/test/standard/formatter_test.rb
+++ b/test/standard/formatter_test.rb
@@ -30,7 +30,7 @@ class Standard::FormatterTest < UnitTest
     @subject.finished([@some_path])
 
     assert_equal <<-MESSAGE.gsub(/^ {6}/, ""), @io.string
-      Congrats, you're done! Delete `.standard_todo.yml` in celebration.
+      Congratulations, you've successfully migrated this project to Standard! Delete `.standard_todo.yml` in celebration.
     MESSAGE
   end
 


### PR DESCRIPTION
Per https://github.com/testdouble/standard/issues/330

The `Standard::Formatter` better handles the situation where a todo file exists, but no files are actually listed within.

## Development Setup

Run `standardrb --generate-todo` to generate a `.standard_todo.yml` file. On `main`, you'll see the warning without files listed while on this branch, the warning does not show.