### PR TITLE
actionable code coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,4 @@ gem "minitest", "~> 5.0"
 gem "pry"
 gem "rake", "~> 13.0"
 gem "gimme"
-
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.5")
-  gem "simplecov"
-end
+gem "single_cov"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ GEM
   specs:
     ast (2.4.2)
     coderay (1.1.3)
-    docile (1.4.0)
     gimme (0.5.0)
     method_source (1.0.0)
     minitest (5.14.4)
@@ -39,12 +38,7 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
-    simplecov (0.21.2)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.3)
+    single_cov (1.6.0)
     unicode-display_width (2.0.0)
 
 PLATFORMS
@@ -57,7 +51,7 @@ DEPENDENCIES
   minitest (~> 5.0)
   pry
   rake (~> 13.0)
-  simplecov
+  single_cov
   standard!
 
 BUNDLED WITH

--- a/test/standard/builds_config_test.rb
+++ b/test/standard/builds_config_test.rb
@@ -1,5 +1,7 @@
 require_relative "../test_helper"
 
+SingleCov.covered!
+
 class Standard::BuildsConfigTest < UnitTest
   DEFAULT_OPTIONS = {
     auto_correct: false,

--- a/test/standard/cli_test.rb
+++ b/test/standard/cli_test.rb
@@ -1,6 +1,8 @@
 require_relative "../test_helper"
 require "fileutils"
 
+SingleCov.covered!
+
 class Standard::CliTest < UnitTest
   def test_autocorrectable
     FileUtils.rm_rf("tmp/cli_test")

--- a/test/standard/rubocop/ext_test.rb
+++ b/test/standard/rubocop/ext_test.rb
@@ -1,7 +1,9 @@
-require_relative "../test_helper"
+require_relative "../../test_helper"
 require "fileutils"
 
-class Standard::CommentDirectiveTest < UnitTest
+SingleCov.covered! uncovered: 1
+
+class Standard::ExtTest < UnitTest
   def test_comment_directive
     fake_out, fake_err, exit_code = do_with_fake_io {
       Standard::Cli.new(["test/fixture/comment_directive_test/disabled.rb"]).run

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,8 @@
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
-begin
-  require "simplecov"
-  SimpleCov.start
-  SimpleCov.start do
-    add_filter "vendor"
-  end
-rescue LoadError
-end
-
+$LOAD_PATH << "lib"
 $LOAD_PATH << "test"
+
+require "single_cov"
+SingleCov.setup :minitest
 
 require "standard"
 require "gimme"


### PR DESCRIPTION
 - almost no runtime overhead
 - tells you when code is not covered (instead of generating a report nobody looks at)
 - encourages that test location/name matches file under test
 - supports branch coverage `a ? b : c` == 2 branches

before:
```
Coverage report generated for Unit Tests to coverage. 234 / 324 LOC (72.22%) covered.
```

after:
```
lib/standard/rubocop/ext.rb new uncovered lines introduced (1 current vs 0 configured)
Lines missing coverage:
lib/standard/rubocop/ext.rb:5
```

I can do the remaining files, but wanted to get a 👍 / 👎 before I put in more work.