### PR TITLE
Switch to consistent shorthand hash syntax

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1355,7 +1355,7 @@ Style/HashLikeCase:
 Style/HashSyntax:
   Enabled: true
   EnforcedStyle: ruby19_no_mixed_keys
-  EnforcedShorthandSyntax: either
+  EnforcedShorthandSyntax: consistent
 
 Style/HashTransformKeys:
   Enabled: false


### PR DESCRIPTION
The only thing that I don't like more than a shorthand hash syntax is mixed syntax. [When standard](https://github.com/testdouble/standard/issues/375) was introducing `EnforcedShorthandSyntax: either` a `consistent` option didn't exist yet (actually `either` didn't exist too, it was introduced thanks to standard :heart: ) but now it should be no brainer to switch to this one.

```ruby
# with either

# good
{foo: foo, bar: bar}

# good
{foo:, bar: bar} # !!!

# good
{foo:, bar:}
```

```ruby
# with consistent

# bad
{foo: , bar: bar}

# good
{foo:, bar:}

# bad
{foo: , bar: baz}

# good
{foo: foo, bar: baz}
```