### PR TITLE
Added Spinal (https://spinalcms.com/) as a Ruby Standard-compliant team

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Here are a few examples of Ruby Standard-compliant teams & projects:
 * [Rebase Interactive](https://www.rebaseinteractive.com/)
 * [Renuo](https://www.renuo.ch/)
 * [RubyCI](https://ruby.ci)
+* [Spinal](https://spinalcms.com/)
 * [Teamtailor](https://www.teamtailor.com/)
 * [thoughtbot](https://thoughtbot.com/)
 


### PR DESCRIPTION
Standard helps keep the Spinal code-base consistent (and helps devs sometimes learn something new). 🙌