### PR TITLE
Instantiate Object-type lint_roller plugins correctly

### DIFF
--- a/lib/standard/plugin/merges_plugins_into_rubocop_config.rb
+++ b/lib/standard/plugin/merges_plugins_into_rubocop_config.rb
@@ -137,6 +137,8 @@ module Standard
       #
       # See: https://github.com/rubocop/rubocop/pull/11833
       def set_target_rails_version_on_all_cops_because_its_technically_not_allowed!(options_config)
+        return unless options_config.key?("AllCops")
+
         options_config["AllCops"]["TargetRailsVersion"] = "~"
       end
 

--- a/test/fixture/plugins/project/olives.rb
+++ b/test/fixture/plugins/project/olives.rb
@@ -1,2 +1,2 @@
-olives = "🫒🫒🫒"
+olives = '🫒🫒🫒'
 puts olives

--- a/test/standard/creates_config_store/merges_user_config_extensions_test.rb
+++ b/test/standard/creates_config_store/merges_user_config_extensions_test.rb
@@ -43,7 +43,8 @@ class Standard::CreatesConfigStore::MergesUserConfigExtensionsTest < UnitTest
         "StyleGuideBaseURL" => "https://standardrb.example.com",
 
         # Allowed to overwrite
-        "MaxFilesInCache" => 33
+        "MaxFilesInCache" => 33,
+        "TargetRailsVersion" => "~"
       }
     }, options_config.to_h)
   end
@@ -72,7 +73,8 @@ class Standard::CreatesConfigStore::MergesUserConfigExtensionsTest < UnitTest
         "TargetRubyVersion" => nil,
         "StyleGuideCopsOnly" => false,
         "StyleGuideBaseURL" => "https://standardrb.example.com",
-        "MaxFilesInCache" => 33
+        "MaxFilesInCache" => 33,
+        "TargetRailsVersion" => "~"
       },
       "Betterment/UnscopedFind" => {
         "Enabled" => true,
@@ -107,7 +109,8 @@ class Standard::CreatesConfigStore::MergesUserConfigExtensionsTest < UnitTest
         "TargetRubyVersion" => nil,
         "StyleGuideCopsOnly" => false,
         "StyleGuideBaseURL" => "https://standardrb.example.com",
-        "MaxFilesInCache" => 33
+        "MaxFilesInCache" => 33,
+        "TargetRailsVersion" => "~"
       },
 
       # First-in wins, deep merge for nested hashes

--- a/test/standard/plugin/merges_plugins_into_rubocop_config_test.rb
+++ b/test/standard/plugin/merges_plugins_into_rubocop_config_test.rb
@@ -75,7 +75,7 @@ class Standard::Plugin::MergesPluginsIntoRubocopConfigTest < UnitTest
     @subject.call(options_config, {}, [], permit_merging: true)
 
     assert_equal({
-      "AllCops" => {}
+      "AllCops" => {"TargetRailsVersion" => "~"}
     }, options_config.to_h)
   end
 
@@ -91,7 +91,7 @@ class Standard::Plugin::MergesPluginsIntoRubocopConfigTest < UnitTest
     ], permit_merging: true)
 
     assert_equal({
-      "AllCops" => {},
+      "AllCops" => {"TargetRailsVersion" => "~"},
       "Fake/Stuff" => {"Enabled" => true, "Plumbus" => "schleem"},
       "Fake/Things" => {"Enabled" => false, "Dingus" => "always"},
       "Fake/Junk" => {"Enabled" => false},
@@ -117,6 +117,13 @@ class Standard::Plugin::MergesPluginsIntoRubocopConfigTest < UnitTest
     assert_equal <<~MSG.chomp, error.message
       Plugin `Broken Plugin' failed to load with error: I'm worse
     MSG
+  end
+
+  module RuboCop::Cop
+    module Breakfast
+      class Eggs < RuboCop::Cop::Base
+      end
+    end
   end
 
   def test_that_first_person_to_set_a_rule_cant_have_the_nested_attributes_overridden
@@ -148,7 +155,7 @@ class Standard::Plugin::MergesPluginsIntoRubocopConfigTest < UnitTest
     ], permit_merging: true)
 
     assert_equal({
-      "AllCops" => {},
+      "AllCops" => {"TargetRailsVersion" => "~"},
       "Breakfast/Eggs" => {
         "Enabled" => true,
         "EnforcedStyle" => "scrambled"
@@ -171,8 +178,15 @@ class Standard::Plugin::MergesPluginsIntoRubocopConfigTest < UnitTest
     ], permit_merging: true)
 
     assert_equal({
-      "AllCops" => {"A" => "a1", "B" => "b1", "C" => "c1", "D" => "d2", "E" => "e3"}
+      "AllCops" => {"A" => "a1", "B" => "b1", "C" => "c1", "D" => "d2", "E" => "e3", "TargetRailsVersion" => "~"}
     }, options_config.to_h)
+  end
+
+  module RuboCop::Cop
+    module Some
+      class Rule < RuboCop::Cop::Base
+      end
+    end
   end
 
   def test_that_all_cops_arrays_are_concated_but_rule_arrays_are_overwritten
@@ -197,7 +211,8 @@ class Standard::Plugin::MergesPluginsIntoRubocopConfigTest < UnitTest
     assert_equal({
       "AllCops" => {
         "fruits" => ["apple", "banana", "tomato", "orange"],
-        "nuts" => ["cashew", "peanut"]
+        "nuts" => ["cashew", "peanut"],
+        "TargetRailsVersion" => "~"
       },
       "Some/Rule" => {
         "candies" => ["lollipop"]

--- a/test/standardrb_test.rb
+++ b/test/standardrb_test.rb
@@ -56,6 +56,8 @@ class StandardrbTest < UnitTest
     refute status.success?
     assert_same_lines <<~MSG, stdout
       #{standard_greeting}
+      standard: Run `standardrb --fix` to potentially fix one problem.
+        olives.rb:1:10: Style/StringLiterals: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
         olives.rb:1:1: Bananas/BananasOnly: Bananas only! No steak or apples or shenanigans.
     MSG
   end


### PR DESCRIPTION
We were instantiating configuration objects from plugins using `RuboCop::Config.new` instead of `RuboCop::Config.create`, which ended up causing subtle differences in how `AllCops` was being handled when merging plugins. Namely, it resulted in the inclusion of _any_ such plugin as disabling all previously-defined cops, which is not what we'd want. (Including a single empty object plugin in your config will effectively disable every built-in cop, which isn't super good).

It still feels like there's more underlying trouble here around `AllCops` option `DisabledByDefault` which was added in 1.28.0, but this will fix the immediate and urgent issue.

Fixes https://github.com/standardrb/standard-rails/issues/4