### PR TITLE
🔧 config/ruby-3.2.yml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
       rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.28.0)
+    rubocop-ast (1.28.1)
       parser (>= 3.2.1.0)
     rubocop-performance (1.16.0)
       rubocop (>= 1.7.0, < 2.0)
@@ -72,4 +72,4 @@ DEPENDENCIES
   standard!
 
 BUNDLED WITH
-   2.3.26
+   2.4.13

--- a/config/ruby-3.1.yml
+++ b/config/ruby-3.1.yml
@@ -1,4 +1,4 @@
-inherit_from: ./base.yml
+inherit_from: ./ruby-3.2.yml
 
 AllCops:
   TargetRubyVersion: 3.1

--- a/config/ruby-3.2.yml
+++ b/config/ruby-3.2.yml
@@ -1,0 +1,4 @@
+inherit_from: ./base.yml
+
+AllCops:
+  TargetRubyVersion: 3.2

--- a/lib/standard/base/plugin.rb
+++ b/lib/standard/base/plugin.rb
@@ -55,6 +55,8 @@ module Standard::Base
         "ruby-3.0.yml"
       elsif desired_version < Gem::Version.new("3.2")
         "ruby-3.1.yml"
+      elsif desired_version < Gem::Version.new("3.3")
+        "ruby-3.2.yml"
       else
         default
       end

--- a/test/standard/base/plugin_test.rb
+++ b/test/standard/base/plugin_test.rb
@@ -8,7 +8,8 @@ module Standard::Base
     end
 
     def test_paths
-      assert_match "base.yml", @subject.rules(LintRoller::Context.new(target_ruby_version: "3.2.1")).value.to_s
+      assert_match "base.yml", @subject.rules(LintRoller::Context.new(target_ruby_version: "3.3.0")).value.to_s
+      assert_match "ruby-3.2.yml", @subject.rules(LintRoller::Context.new(target_ruby_version: "3.2.1")).value.to_s
       assert_match "ruby-2.7.yml", @subject.rules(LintRoller::Context.new(target_ruby_version: Gem::Version.new("2.8.2"))).value.to_s
       assert_match "ruby-1.9.yml", @subject.rules(LintRoller::Context.new(target_ruby_version: Gem::Version.new("1.9.3"))).value.to_s
     end


### PR DESCRIPTION
- Fixes https://github.com/standardrb/standard/issues/559
- Watched https://www.youtube.com/watch?v=8rLe_qmH84k - add latest Ruby
- Note: *current* release of `standard` already depends on the released version of RuboCop (1.50.2) that [added support](https://github.com/rubocop/rubocop/commit/5fa1573ef01ef9f93808a7a249e53f2930d3002a) (experimental) for current `ruby-head` (which is Ruby 3.3) via `TargetRubyVersion: 3.3`.
- There was one failing spec because the test expects Ruby 3.2 to be the base config, instead of having the base represent Ruby 3.3 (current ruby-head).
- Latest rubygems/bundler was [released 5 hours](https://github.com/rubygems/rubygems/releases/tag/v3.4.13) ago!