### PR TITLE
🐛 Ruby 1.8 & 1.9 do not support percent literal syntax

### DIFF
--- a/config/ruby-1.9.yml
+++ b/config/ruby-1.9.yml
@@ -5,3 +5,7 @@ Style/Encoding:
 
 Style/HashConversion:
   Enabled: false
+
+# Percent delimiters are not supported until Ruby 2.0
+Style/PercentLiteralDelimiters:
+  Enabled: false


### PR DESCRIPTION
Standard's `base.yml` has the following rule, which is great:
```
# Set in standard's base.yml.
Style/PercentLiteralDelimiters:
  Enabled: true
  PreferredDelimiters:
    default: ()
    '%i': '[]'
    '%I': '[]'
    '%r': '{}'
    '%w': '[]'
    '%W': '[]'
```

However, it needs to be disabled for the oldest Rubies.  The percent literal syntax is not supported by codebases that need to continue to support Ruby 1.8 and 1.9.  The answer to that in the RuboCop documentation is ([from `Style/SymbolArray`](https://msp-greg.github.io/rubocop/RuboCop/Cop/Style/SymbolArray.html)):

> Checks for array literals made up of symbols that are not using the %i() syntax.
> Alternatively, it checks for symbol arrays using the %i() syntax on projects which do not want to use that syntax, perhaps because they support a version of Ruby lower than 2.0.

This means that the enforcement can be set to ensure compatibility with Ruby 1.8 and 1.9, but within Standard's rules we will merely disable it.

```
Style/PercentLiteralDelimiters:
  Enabled: false
```

Fixes https://github.com/standardrb/standard/issues/562

Note: since standard's goal is not to prioritize enforcement of compatibility with older versions of Ruby, I've added the "compatible" version of these changes to [`standard-rubocop-lts`](https://github.com/rubocop-lts/standard-rubocop-lts) as a "buffer" against unexpectedly breaking old rubies (see also: https://github.com/standardrb/standard/issues/561#issuecomment-1563291835).