### PR TITLE
Ignore workspace/didChangeConfiguration

### DIFF
--- a/lib/standard/lsp/routes.rb
+++ b/lib/standard/lsp/routes.rb
@@ -75,6 +75,10 @@ module Standard
         @writer.write({id: request[:id], result: format_file(uri)})
       end
 
+      handle "workspace/didChangeConfiguration" do |_request|
+        @logger.puts "Ignoring workspace/didChangeConfiguration"
+      end
+
       handle "workspace/didChangeWatchedFiles" do |request|
         if request[:params][:changes].any? { |change| change[:uri].end_with?(".standard.yml") }
           @logger.puts "Configuration file changed; restart required"


### PR DESCRIPTION
When using `standard` with [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig), the server receives a `workspace/didChangeConfiguration` message immediately after starting.

Standard currently returns an `INVALID_SERVER_MESSAGE` which causes neovim to display lots of angry errors.

I've added a route to ignore this LSP message while logging that we're doing that.