### PR TITLE
Update Rubocop CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,12 +450,14 @@ default rulesets, just as you would any other gem:
 ```yaml
 require:
   - standard
+  - standard-custom
+  - standard-performance
   - rubocop-performance
 
 inherit_gem:
   standard: config/base.yml
-  standard-performance: config/base.yml
   standard-custom: config/base.yml
+  standard-performance: config/base.yml
 ```
 
 ## Who uses Standard Ruby?


### PR DESCRIPTION
TIL that `standard-custom` and `standard-performance` may  need to be added to the `require` list within the Rubocop configuration (thx, @searls!). Adding this so no one else trips on this and bogs down the issue tracker about an unsupported pattern.