### PR TITLE
Enable `Style/UnlessLogicalOperators`

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1788,7 +1788,8 @@ Style/UnlessElse:
   Enabled: true
 
 Style/UnlessLogicalOperators:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: forbid_mixed_logical_operators
 
 Style/UnpackFirst:
   Enabled: true


### PR DESCRIPTION
Enabled style: `Style/UnlessLogicalOperators` with `forbid_mixed_logical_operators` (default behavior).
Related issue: https://github.com/standardrb/standard/issues/573
Cop reference: https://docs.rubocop.org/rubocop/cops_style.html#styleunlesslogicaloperators
```ruby
# bad
return unless a || b && c
return unless a && b || c
return unless a && b and c
return unless a || b or c
return unless a && b or c
return unless a || b and c

# good
return unless a && b && c
return unless a || b || c
return unless a and b and c
return unless a or b or c
return unless a?
```

As discussed, I propose to forbid mixing logical operators with "unless". Mixing logical operators with "unless" makes it hard to read the code.

@camilopayan 
