### PR TITLE
Fix incorrect `diagnosticProvider` value of LSP

### DIFF
--- a/lib/standard/lsp/routes.rb
+++ b/lib/standard/lsp/routes.rb
@@ -27,7 +27,10 @@ module Standard
         @writer.write(id: request[:id], result: Proto::Interface::InitializeResult.new(
           capabilities: Proto::Interface::ServerCapabilities.new(
             document_formatting_provider: true,
-            diagnostic_provider: true,
+            diagnostic_provider: LanguageServer::Protocol::Interface::DiagnosticOptions.new(
+              inter_file_dependencies: false,
+              workspace_diagnostics: false
+            ),
             text_document_sync: Proto::Interface::TextDocumentSyncOptions.new(
               change: Proto::Constant::TextDocumentSyncKind::FULL,
               open_close: true

--- a/test/standard/runners/lsp_test.rb
+++ b/test/standard/runners/lsp_test.rb
@@ -18,7 +18,7 @@ class Standard::Runners::LspTest < UnitTest
       result: {capabilities: {
         textDocumentSync: {openClose: true, change: 1},
         documentFormattingProvider: true,
-        diagnosticProvider: true
+        diagnosticProvider: {interFileDependencies: false, workspaceDiagnostics: false}
       }},
       jsonrpc: "2.0"
     }


### PR DESCRIPTION
## Summary

This PR fixes incorrect `diagnosticProvider` value of LSP.

`diagnosticProvider` cannot accept `true` as below. This PR replaces the originally acceptable value.

```typescript
/**
 * The server has support for pull model diagnostics.
 *
 * @since 3.17.0
 */
diagnosticProvider?: DiagnosticOptions | DiagnosticRegistrationOptions;
```

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize

## Additional Information

This issue was found in https://github.com/rubocop/rubocop/issues/12154.