### PR TITLE
change link for emacs integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ We've added a number of editing guides for getting started:
 - [vim](https://github.com/standardrb/standard/wiki/IDE:-vim)
 - [neovim](https://github.com/standardrb/standard/wiki/IDE:-neovim)
 - [RubyMine](https://www.jetbrains.com/help/ruby/rubocop.html#disable_rubocop)
-- [emacs](https://github.com/julianrubisch/flycheck-standardrb)
+- [emacs](https://www.flycheck.org/en/latest/languages.html#syntax-checker-ruby-standard)
 - [Atom](https://github.com/standardrb/standard/wiki/IDE:-Atom)
 
 If you'd like to help by creating a guide, please draft one [in an


### PR DESCRIPTION
Update the link to point to Flycheck's built in standard checker. The current link points to an unpackaged repo for a flycheck checker that is more complicated to install than configuring a variable for Flycheck.