### PR TITLE
Updates rubocop to 1.57.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Updates rubocop to [1.57.2](https://github.com/rubocop/rubocop/releases/tag/v1.57.2)
+
 ## 1.31.2
 
 * Updates rubocop to [1.52.4](https://github.com/rubocop/rubocop/releases/tag/v1.52.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     standard (1.31.2)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.56.4)
+      rubocop (~> 1.57.2)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.2)
 
@@ -12,7 +12,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    base64 (0.1.1)
     docile (1.4.0)
     gimme (0.5.0)
     json (2.6.3)
@@ -32,12 +31,11 @@ GEM
     rake (13.0.6)
     regexp_parser (2.8.2)
     rexml (3.2.6)
-    rubocop (1.56.4)
-      base64 (~> 0.1.1)
+    rubocop (1.57.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.3)
+      parser (>= 3.2.2.4)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
@@ -78,4 +76,4 @@ DEPENDENCIES
   standard!
 
 BUNDLED WITH
-   2.3.26
+   2.4.21

--- a/config/base.yml
+++ b/config/base.yml
@@ -1659,6 +1659,9 @@ Style/SingleArgumentDig:
 Style/SingleLineBlockParams:
   Enabled: false
 
+Style/SingleLineDoEndBlock:
+  Enabled: false
+
 Style/SingleLineMethods:
   Enabled: true
   AllowIfMethodIsEmpty: false

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.add_dependency "rubocop", "~> 1.56.4"
+  spec.add_dependency "rubocop", "~> 1.57.2"
 
   spec.add_dependency "lint_roller", "~> 1.0"
   spec.add_dependency "standard-custom", "~> 1.0.0"


### PR DESCRIPTION
This was motivated by the dropping of the default base64 gem from rubocop's requirements