### PR TITLE
Add link to Helix configuration in editor support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ We've added a number of editing guides for getting started:
 - [neovim](https://github.com/standardrb/standard/wiki/IDE:-neovim)
 - [RubyMine](https://www.jetbrains.com/help/ruby/rubocop.html#disable_rubocop)
 - [emacs](https://www.flycheck.org/en/latest/languages.html#syntax-checker-ruby-standard)
+- [Helix](https://github.com/helix-editor/helix/wiki/External-formatter-configuration#standardrb)
 - [Atom](https://github.com/standardrb/standard/wiki/IDE:-Atom)
 
 If you'd like to help by creating a guide, please draft one [in an


### PR DESCRIPTION
This adds a link to a page on the Helix editor wiki that shows how to configure it to use Standard for formatting.

Closes #595, cc @camilopayan