### PR TITLE
Use consistent style for `Lint/SymbolConversion`

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -773,6 +773,7 @@ Lint/SuppressedException:
 
 Lint/SymbolConversion:
   Enabled: true
+  EnforcedStyle: consistent
 
 Lint/Syntax:
   Enabled: true


### PR DESCRIPTION
I'd like to suggest to use consistent style for `Lint/SymbolConversion`. Examples from [rubocop docs](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/SymbolConversion):
```ruby
# bad
{
  a: 1,
  'b-c': 2
}

# good (quote all keys if any need quoting)
{
  'a': 1,
  'b-c': 2
}

# good (no quoting required)
{
  a: 1,
  b: 2
}
```