### PR TITLE
Remove incorrect textDocument/diagnostic request handler

### DIFF
--- a/lib/standard/lsp/routes.rb
+++ b/lib/standard/lsp/routes.rb
@@ -13,7 +13,7 @@ module Standard
       end
 
       def self.handle(name, &block)
-        define_method("handle_#{name}", &block)
+        define_method(:"handle_#{name}", &block)
       end
 
       def for(name)
@@ -51,10 +51,8 @@ module Standard
         end
       end
 
-      handle "textDocument/diagnostic" do |request|
-        doc = request[:params][:textDocument]
-        result = diagnostic(doc[:uri], doc[:text])
-        @writer.write(result)
+      handle "textDocument/diagnostic" do |_request|
+        # no op, diagnostics are handled in textDocument/didChange
       end
 
       handle "textDocument/didChange" do |request|

--- a/test/standard/runners/lsp_test.rb
+++ b/test/standard/runners/lsp_test.rb
@@ -72,40 +72,13 @@ class Standard::Runners::LspTest < UnitTest
       jsonrpc: "2.0",
       params: {
         textDocument: {
-          languageId: "ruby",
-          text: "def hi\n  [1, 2,\n   3  ]\nend\n",
-          uri: "file:///path/to/file.rb",
-          version: 0
+          uri: "file:///path/to/file.rb"
         }
       }
     })
 
     assert_equal "", err.string
-    assert_equal 1, msgs.count
-    assert_equal({
-      method: "textDocument/publishDiagnostics",
-      params: {
-        diagnostics: [
-          {code: "Layout/ArrayAlignment",
-           message: "Use one level of indentation for elements following the first line of a multi-line array.",
-           range: {start: {character: 3, line: 2}, end: {character: 3, line: 2}},
-           severity: 3,
-           source: "standard"},
-          {code: "Layout/ExtraSpacing",
-           message: "Unnecessary spacing detected.",
-           range: {start: {character: 4, line: 2}, end: {character: 4, line: 2}},
-           severity: 3,
-           source: "standard"},
-          {code: "Layout/SpaceInsideArrayLiteralBrackets",
-           message: "Do not use space inside array brackets.",
-           range: {start: {character: 4, line: 2}, end: {character: 5, line: 2}},
-           severity: 3,
-           source: "standard"}
-        ],
-        uri: "file:///path/to/file.rb"
-      },
-      jsonrpc: "2.0"
-    }, msgs.first)
+    assert_equal 0, msgs.count
   end
 
   def test_format


### PR DESCRIPTION
The parameters for this request only include a `textDocument`, which is a `TextDocumentIdentifier`, an `identifier?` and a `previousResultId?`. The `TextDocumentIdentifer` only has a `uri` property, which is of type `DocumentUri`.

According to the LSP spec:

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_diagnostic

this request does not include the contents of the file (which is what the handler was expecting).

I have simply made the handling of this request a no-op, since diagnostics are already sent to the client in `textDocument/didChange`.

Note: This also fixes formatting problems related to Neovim 0.10 described in #575