### PR TITLE
Remove unused Gimme dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gemspec
 gem "bundler"
 gem "minitest", "~> 5.0"
 gem "rake", "~> 13.0"
-gem "gimme"
 gem "m"
 
 # You may want to run these off path locally:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,6 @@ GEM
   specs:
     ast (2.4.2)
     docile (1.4.0)
-    gimme (0.5.0)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
@@ -68,7 +67,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
-  gimme
   m
   minitest (~> 5.0)
   rake (~> 13.0)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,6 @@ end
 $LOAD_PATH << "test"
 
 require "standard"
-require "gimme"
 require "minitest/autorun"
 
 class UnitTest < Minitest::Test
@@ -22,10 +21,6 @@ class UnitTest < Minitest::Test
 
   def before_setup
     RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, nil)
-  end
-
-  def teardown
-    Gimme.reset
   end
 
   protected


### PR DESCRIPTION
I noticed `gimme` isn't used, so should be safe to remove?