### PR TITLE
Update Github Actions plugin in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ above command and will subsequently manage the server process for you.
 Various continuous integration and quality-checking tools have been made to
 support Standard Ruby, as well.
 
-* [Github Actions](https://github.com/andrewmcodes/standardrb-action)
+* [Github Actions](https://github.com/kmcphillips/standardrb-action) [(Marketplace)](https://github.com/marketplace/actions/standardrb-linter)
 * [Code Climate](https://github.com/standardrb/standard/wiki/CI:-Code-Climate)
 * [Pronto](https://github.com/julianrubisch/pronto-standardrb)
 * [Danger](https://github.com/ashfurrow/danger-rubocop/)


### PR DESCRIPTION
The originally recommended Github Action in the README has gone unmaintained and no longer works due to the Ruby version being too old. 

See:
* https://github.com/andrewmcodes/standardrb-action/pull/20
* https://github.com/andrewmcodes/standardrb-action/pull/23
* https://github.com/andrewmcodes/standardrb-action/commits/main/ (last commit 2 years ago)

I have forked it, updated the ruby version, tidied and cleaned up some out of date stuff, and added support for the [`standard-rails`](https://github.com/standardrb/standard-rails) plugin.

I've published it to the marketplace: https://github.com/marketplace/actions/standardrb-linter

I don't mind maintaining it going forward. There's not much code in there.