### PR TITLE
[minor casing change] Github -> GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ above command and will subsequently manage the server process for you.
 Various continuous integration and quality-checking tools have been made to
 support Standard Ruby, as well.
 
-* [Github Actions](https://github.com/standardrb/standard-ruby-action)
+* [GitHub Actions](https://github.com/standardrb/standard-ruby-action)
 * [Code Climate](https://github.com/standardrb/standard/wiki/CI:-Code-Climate)
 * [Pronto](https://github.com/julianrubisch/pronto-standardrb)
 * [Danger](https://github.com/ashfurrow/danger-rubocop/)


### PR DESCRIPTION
Finally, the disambiguation we've all been wanting.  No functionality changes.