### PR TITLE
change regex percent literal delimiter to singlequote

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1007,7 +1007,7 @@ Style/PercentLiteralDelimiters:
     default: ()
     '%i': '[]'
     '%I': '[]'
-    '%r': '{}'
+    '%r': "''"
     '%w': '[]'
     '%W': '[]'
 


### PR DESCRIPTION
Curly braces are a part of Regex syntax (`.{3,}`, `.{,9}` etc.),  so if the literal contains curlybraces, I have to use some other unspecified fallback delimiters. Bikeshedding ensues. Let's use delimiters that are not a part of Regex syntax and are less likely to appear in them - singlequotes. This goes nicely with string literals using doublequotes.