### PR TITLE
LSP: Don't advertise support for Pull Diagnostics

### DIFF
--- a/lib/standard/lsp/routes.rb
+++ b/lib/standard/lsp/routes.rb
@@ -27,10 +27,6 @@ module Standard
         @writer.write(id: request[:id], result: Proto::Interface::InitializeResult.new(
           capabilities: Proto::Interface::ServerCapabilities.new(
             document_formatting_provider: true,
-            diagnostic_provider: LanguageServer::Protocol::Interface::DiagnosticOptions.new(
-              inter_file_dependencies: false,
-              workspace_diagnostics: false
-            ),
             text_document_sync: Proto::Interface::TextDocumentSyncOptions.new(
               change: Proto::Constant::TextDocumentSyncKind::FULL,
               open_close: true
@@ -49,10 +45,6 @@ module Standard
           @writer.write(id: request[:id], result: nil)
           @logger.puts "Exiting..."
         end
-      end
-
-      handle "textDocument/diagnostic" do |_request|
-        # no op, diagnostics are handled in textDocument/didChange
       end
 
       handle "textDocument/didChange" do |request|

--- a/test/standard/runners/lsp_test.rb
+++ b/test/standard/runners/lsp_test.rb
@@ -17,8 +17,7 @@ class Standard::Runners::LspTest < UnitTest
       id: 2,
       result: {capabilities: {
         textDocumentSync: {openClose: true, change: 1},
-        documentFormattingProvider: true,
-        diagnosticProvider: {interFileDependencies: false, workspaceDiagnostics: false}
+        documentFormattingProvider: true
       }},
       jsonrpc: "2.0"
     }
@@ -64,21 +63,6 @@ class Standard::Runners::LspTest < UnitTest
       },
       jsonrpc: "2.0"
     }, msgs.first)
-  end
-
-  def test_diagnotic_route
-    msgs, err = run_server_on_requests({
-      method: "textDocument/diagnostic",
-      jsonrpc: "2.0",
-      params: {
-        textDocument: {
-          uri: "file:///path/to/file.rb"
-        }
-      }
-    })
-
-    assert_equal "", err.string
-    assert_equal 0, msgs.count
   end
 
   def test_format


### PR DESCRIPTION
Standard doesn't actually support the Pull Diagnostics that were added in LSP 3.17. It supports Push Diagnostics just fine.

Pull Diagnostics: Advertise support via `diagnosticProvider` in the server capabilities. Respond to `textDocument/diagnostic` with diagnostics. Note that the `textDocument/diagnostic` message does not include the text to be diagnosed.

Push Diagnostics: At some point after receiving a `textDocument/didOpen` or a `textDocument/didChange`, send a `textDocument/publishDiagnostics` to the client.

Pull Diagnostics give the client more control over when diagnostics are computed and received and are preferred going forward. Since Standard doesn't actually support them (yet?) we shouldn't advertise that we do.

## Context

I figured all of this out while trying to figure out why neovim 0.10 nightly wouldn't update Standard's diagnostics until I forced a buffer reload. It seems that neovim is getting confused when Standard doesn't give a response to `textDocument/diagnostic`.

Turning off the advertisement for Pull Diagnostics caused neovim to stop sending the `textDocument/diagnostic` messages entirely and restored support for the existing `textDocument/publishDiagnostics` messages.

## References

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#serverCapabilities
https://atlee.ca/posts/pull-diagnostic-support-for-neovim/