### PR TITLE
Add support for Ruby LSP as a built-in add-on

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,4 +1,4 @@
-ruby_version: 2.6
+ruby_version: 3.0
 ignore:
   - tmp/**/*
   - test/fixture/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem "bundler"
 gem "minitest", "~> 5.0"
 gem "rake", "~> 13.0"
 gem "m"
+gem "mutex_m"
+gem "ruby-lsp"
 
 # You may want to run these off path locally:
 # gem "lint_roller", path: "../lint_roller"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet-runtime (0.5.11380)
+    sorbet-runtime (0.5.11385)
     standard-custom (1.0.2)
       lint_roller (~> 1.0)
       rubocop (~> 1.50)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,10 +21,12 @@ GEM
       rake (>= 0.9.2.2)
     method_source (1.0.0)
     minitest (5.20.0)
+    mutex_m (0.2.0)
     parallel (1.23.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
+    prism (0.27.0)
     racc (1.7.1)
     rainbow (3.1.1)
     rake (13.0.6)
@@ -46,6 +48,10 @@ GEM
     rubocop-performance (1.21.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-lsp (0.16.6)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 0.23.0, < 0.28)
+      sorbet-runtime (>= 0.5.10782)
     ruby-progressbar (1.13.0)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -53,6 +59,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet-runtime (0.5.11380)
     standard-custom (1.0.2)
       lint_roller (~> 1.0)
       rubocop (~> 1.50)
@@ -69,9 +76,11 @@ DEPENDENCIES
   bundler
   m
   minitest (~> 5.0)
+  mutex_m
   rake (~> 13.0)
+  ruby-lsp
   simplecov
   standard!
 
 BUNDLED WITH
-   2.4.12
+   2.5.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,4 +83,4 @@ DEPENDENCIES
   standard!
 
 BUNDLED WITH
-   2.5.7
+   2.4.12

--- a/lib/ruby_lsp/standard/addon.rb
+++ b/lib/ruby_lsp/standard/addon.rb
@@ -1,3 +1,4 @@
+require "standard"
 require_relative "wraps_built_in_lsp_standardizer"
 
 module RubyLsp

--- a/lib/ruby_lsp/standard/addon.rb
+++ b/lib/ruby_lsp/standard/addon.rb
@@ -16,6 +16,7 @@ module RubyLsp
         warn "Activating Standard Ruby LSP addon v#{::Standard::VERSION}"
         @wraps_built_in_lsp_standardizer = WrapsBuiltinLspStandardizer.new
         global_state.register_formatter("standard", @wraps_built_in_lsp_standardizer)
+        register_additional_file_watchers(global_state, message_queue)
         warn "Initialized Standard Ruby LSP addon #{::Standard::VERSION}"
       end
 
@@ -32,7 +33,7 @@ module RubyLsp
           params: Interface::RegistrationParams.new(
             registrations: [
               Interface::Registration.new(
-                id: "workspace/didChangeWatchedFilesMyGem",
+                id: "workspace/didChangeWatchedFilesStandard",
                 method: "workspace/didChangeWatchedFiles",
                 register_options: Interface::DidChangeWatchedFilesRegistrationOptions.new(
                   watchers: [

--- a/lib/ruby_lsp/standard/addon.rb
+++ b/lib/ruby_lsp/standard/addon.rb
@@ -1,0 +1,55 @@
+require_relative "wraps_built_in_lsp_standardizer"
+
+module RubyLsp
+  module Standard
+    class Addon < ::RubyLsp::Addon
+      def initializer
+        @wraps_built_in_lsp_standardizer = nil
+      end
+
+      def name
+        "Standard Ruby"
+      end
+
+      def activate(global_state, message_queue)
+        @wraps_built_in_lsp_standardizer = WrapsBuiltinLspStandardizer.new
+        global_state.register_formatter("standard", @wraps_built_in_lsp_standardizer)
+      end
+
+      def deactivate
+        @wraps_built_in_lsp_standardizer = nil
+      end
+
+      def register_additional_file_watchers(global_state, message_queue)
+        return unless global_state.supports_watching_files
+
+        message_queue << Request.new(
+          id: "standard-file-watcher",
+          method: "client/registerCapability",
+          params: Interface::RegistrationParams.new(
+            registrations: [
+              Interface::Registration.new(
+                id: "workspace/didChangeWatchedFilesMyGem",
+                method: "workspace/didChangeWatchedFiles",
+                register_options: Interface::DidChangeWatchedFilesRegistrationOptions.new(
+                  watchers: [
+                    Interface::FileSystemWatcher.new(
+                      glob_pattern: "**/.standard.yml",
+                      kind: Constant::WatchKind::CREATE | Constant::WatchKind::CHANGE | Constant::WatchKind::DELETE
+                    )
+                  ]
+                )
+              )
+            ]
+          )
+        )
+      end
+
+      def workspace_did_change_watched_files(changes)
+        if changes.any? { |change| change[:uri].end_with?(".standard.yml") }
+          @wraps_built_in_lsp_standardizer.init!
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/standard/addon.rb
+++ b/lib/ruby_lsp/standard/addon.rb
@@ -13,8 +13,10 @@ module RubyLsp
       end
 
       def activate(global_state, message_queue)
+        warn "Activating Standard Ruby LSP addon v#{::Standard::VERSION}"
         @wraps_built_in_lsp_standardizer = WrapsBuiltinLspStandardizer.new
         global_state.register_formatter("standard", @wraps_built_in_lsp_standardizer)
+        warn "Initialized Standard Ruby LSP addon #{::Standard::VERSION}"
       end
 
       def deactivate
@@ -49,6 +51,7 @@ module RubyLsp
       def workspace_did_change_watched_files(changes)
         if changes.any? { |change| change[:uri].end_with?(".standard.yml") }
           @wraps_built_in_lsp_standardizer.init!
+          warn "Re-initialized Standard Ruby LSP addon #{::Standard::VERSION} due to .standard.yml file change"
         end
       end
     end

--- a/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
+++ b/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
@@ -12,6 +12,7 @@ module RubyLsp
           @config,
           ::Standard::Lsp::Logger.new
         )
+        @rubocop_config = @config.rubocop_config_store.for_pwd
         @cop_registry = RuboCop::Cop::Registry.global.to_h
       end
 
@@ -73,7 +74,7 @@ module RubyLsp
       # https://github.com/Shopify/ruby-lsp/blob/4c1906172add4d5c39c35d3396aa29c768bfb898/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb#L84
       def code_description(cop_name)
         if (cop_class = @cop_registry[cop_name]&.first)
-          if (doc_url = cop_class.documentation_url)
+          if (doc_url = cop_class.documentation_url(@rubocop_config))
             Interface::CodeDescription.new(href: doc_url)
           end
         end

--- a/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
+++ b/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
@@ -1,0 +1,89 @@
+require "lint_roller"
+require_relative "../../standard/builds_config"
+require_relative "../../standard/lsp/standardizer"
+require_relative "../../standard/lsp/logger"
+
+module RubyLsp
+  module Standard
+    class WrapsBuiltinLspStandardizer
+      include RubyLsp::Requests::Support::Formatter
+      def initialize
+        init!
+      end
+
+      def init!
+        @config = ::Standard::BuildsConfig.new.call(ARGV)
+        @standardizer = ::Standard::Lsp::Standardizer.new(
+          @config,
+          ::Standard::Lsp::Logger.new
+        )
+        @cop_registry = RuboCop::Cop::Registry.global.to_h
+      end
+
+      def run_formatting(uri, document)
+        # TODO: this isn't being triggered by my test
+        @standardizer.format(uri_to_path(uri), document.source)
+      end
+
+      def run_diagnostic(uri, document)
+        offenses = @standardizer.offenses(uri_to_path(uri), document.source)
+
+        offenses.map { |o|
+          cop_name = o[:cop_name]
+
+          msg = o[:message].delete_prefix(cop_name)
+          loc = o[:location]
+
+          severity = case o[:severity]
+          when "error", "fatal"
+            RubyLsp::Constant::DiagnosticSeverity::ERROR
+          when "warning"
+            RubyLsp::Constant::DiagnosticSeverity::WARNING
+          when "convention"
+            RubyLsp::Constant::DiagnosticSeverity::INFORMATION
+          when "refactor", "info"
+            RubyLsp::Constant::DiagnosticSeverity::HINT
+          else # the above cases fully cover what RuboCop sends at this time
+            logger.puts "Unknown severity: #{severity.inspect}"
+            RubyLsp::Constant::DiagnosticSeverity::HINT
+          end
+
+          RubyLsp::Interface::Diagnostic.new(
+            code: cop_name,
+            code_description: code_description(cop_name),
+            message: msg,
+            source: "Standard Ruby",
+            severity: severity,
+            range: RubyLsp::Interface::Range.new(
+              start: RubyLsp::Interface::Position.new(line: loc[:start_line] - 1, character: loc[:start_column] - 1),
+              end: RubyLsp::Interface::Position.new(line: loc[:last_line] - 1, character: loc[:last_column] - 1)
+            )
+            # TODO: do I need something like this?
+            # See: https://github.com/Shopify/ruby-lsp/blob/4c1906172add4d5c39c35d3396aa29c768bfb898/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb#L62
+            # data: {
+            #   correctable: @offense.correctable?,
+            #   code_actions: to_lsp_code_actions
+            # }
+          )
+        }
+      end
+
+      private
+
+      # duplicated from: lib/standard/lsp/routes.rb
+      def uri_to_path(uri)
+        uri.sub(%r{^file://}, "")
+      end
+
+      # lifted from:
+      # https://github.com/Shopify/ruby-lsp/blob/4c1906172add4d5c39c35d3396aa29c768bfb898/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb#L84
+      def code_description(cop_name)
+        if (cop_class = @cop_registry[cop_name]&.first)
+          if (doc_url = cop_class.documentation_url)
+            Interface::CodeDescription.new(href: doc_url)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
+++ b/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
@@ -21,7 +21,6 @@ module RubyLsp
       end
 
       def run_formatting(uri, document)
-        # TODO: this isn't being triggered by my test
         @standardizer.format(uri_to_path(uri), document.source)
       end
 
@@ -72,7 +71,7 @@ module RubyLsp
 
       # duplicated from: lib/standard/lsp/routes.rb
       def uri_to_path(uri)
-        uri.sub(%r{^file://}, "")
+        uri.to_s.sub(%r{^file://}, "")
       end
 
       # lifted from:

--- a/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
+++ b/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
@@ -53,12 +53,21 @@ module RubyLsp
               start: RubyLsp::Interface::Position.new(line: loc[:start_line] - 1, character: loc[:start_column] - 1),
               end: RubyLsp::Interface::Position.new(line: loc[:last_line] - 1, character: loc[:last_column] - 1)
             )
-            # TODO: do I need something like this?
+            # TODO: We need to do something like to support quickfixes thru code actions
             # See: https://github.com/Shopify/ruby-lsp/blob/4c1906172add4d5c39c35d3396aa29c768bfb898/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb#L62
             # data: {
-            #   correctable: @offense.correctable?,
+            #   correctable: correctable?(offense),
             #   code_actions: to_lsp_code_actions
             # }
+            #
+            # Right now, our offenses are all just JSON parsed from stdout shelling to RuboCop, so
+            # it seems we don't have the corrector available to us.
+            #
+            # Lifted from:
+            # https://github.com/Shopify/ruby-lsp/blob/8d4c17efce4e8ecc8e7c557ab2981db6b22c0b6d/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb#L201
+            # def correctable?(offense)
+            #   !offense.corrector.nil?
+            # end
           )
         }
       end

--- a/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
+++ b/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
@@ -1,8 +1,3 @@
-require "lint_roller"
-require_relative "../../standard/builds_config"
-require_relative "../../standard/lsp/standardizer"
-require_relative "../../standard/lsp/logger"
-
 module RubyLsp
   module Standard
     class WrapsBuiltinLspStandardizer

--- a/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
+++ b/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
@@ -7,7 +7,7 @@ module RubyLsp
       end
 
       def init!
-        @config = ::Standard::BuildsConfig.new.call(ARGV)
+        @config = ::Standard::BuildsConfig.new.call([])
         @standardizer = ::Standard::Lsp::Standardizer.new(
           @config,
           ::Standard::Lsp::Logger.new

--- a/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
+++ b/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
@@ -51,7 +51,7 @@ module RubyLsp
             severity: severity,
             range: RubyLsp::Interface::Range.new(
               start: RubyLsp::Interface::Position.new(line: loc[:start_line] - 1, character: loc[:start_column] - 1),
-              end: RubyLsp::Interface::Position.new(line: loc[:last_line] - 1, character: loc[:last_column] - 1)
+              end: RubyLsp::Interface::Position.new(line: loc[:last_line] - 1, character: loc[:last_column])
             )
             # TODO: We need to do something like to support quickfixes thru code actions
             # See: https://github.com/Shopify/ruby-lsp/blob/4c1906172add4d5c39c35d3396aa29c768bfb898/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb#L62

--- a/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
+++ b/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
@@ -66,8 +66,13 @@ module RubyLsp
       private
 
       # duplicated from: lib/standard/lsp/routes.rb
+      # modified to incorporate Ruby LSP's to_standardized_path method
       def uri_to_path(uri)
-        uri.to_s.sub(%r{^file://}, "")
+        if uri.respond_to?(:to_standardized_path) && !(standardized_path = uri.to_standardized_path).nil?
+          standardized_path
+        else
+          uri.to_s.sub(%r{^file://}, "")
+        end
       end
 
       # lifted from:

--- a/lib/standard/plugin/merges_plugins_into_rubocop_config.rb
+++ b/lib/standard/plugin/merges_plugins_into_rubocop_config.rb
@@ -154,7 +154,7 @@ module Standard
       end
 
       def except(hash_or_config, keys)
-        hash_or_config.to_h.reject { |key, _| keys.include?(key) }.to_h
+        hash_or_config.to_h.except(*keys).to_h
       end
 
       # Always deletes nil entries, always overwrites arrays

--- a/test/fixture/ruby_lsp/simple.rb
+++ b/test/fixture/ruby_lsp/simple.rb
@@ -1,0 +1,2 @@
+s = 'hi'
+puts s

--- a/test/ruby_lsp_addon_test.rb
+++ b/test/ruby_lsp_addon_test.rb
@@ -51,7 +51,7 @@ class RubyLspAddonTest < UnitTest
       assert_equal 1, result.response.items.size
       item = result.response.items.first
       assert_equal({line: 0, character: 4}, item.range.start.to_hash)
-      assert_equal({line: 0, character: 10}, item.range.end.to_hash)
+      assert_equal({line: 0, character: 11}, item.range.end.to_hash)
       assert_equal RubyLsp::Constant::DiagnosticSeverity::INFORMATION, item.severity
       assert_equal "Style/StringLiterals", item.code
       assert_equal "https://docs.rubocop.org/rubocop/cops_style.html#stylestringliterals", item.code_description.href

--- a/test/ruby_lsp_addon_test.rb
+++ b/test/ruby_lsp_addon_test.rb
@@ -1,5 +1,21 @@
-require "ruby_lsp/internal"
+# All of these requires were needed because `ruby_lsp/internal` mutates rubocop
+# in a way that breaks test/standard/cli_test.rb
+require "sorbet-runtime"
+require "language_server-protocol"
+require "ruby_lsp/base_server"
+require "ruby_lsp/server"
+require "ruby_lsp/requests"
+require "ruby_lsp/addon"
+require "ruby_lsp/utils"
+require "ruby_lsp/store"
+require "ruby_lsp/document"
+require "ruby_lsp/global_state"
+require "core_ext/uri"
+require "ruby_indexer/ruby_indexer"
+require "ruby_lsp/ruby_document"
+require "prism"
 require "ruby_lsp/standard/addon"
+
 require_relative "test_helper"
 
 class RubyLspAddonTest < UnitTest

--- a/test/ruby_lsp_addon_test.rb
+++ b/test/ruby_lsp_addon_test.rb
@@ -17,7 +17,7 @@ class RubyLspAddonTest < UnitTest
       s = 'hello'
       puts s
     RUBY
-    with_server(source) do |server, uri|
+    with_server(source, "test/fixture/ruby_lsp/simple.rb") do |server, uri|
       server.process_message(
         id: 1,
         method: "textDocument/formatting",
@@ -27,7 +27,18 @@ class RubyLspAddonTest < UnitTest
       result = server.pop_response
 
       assert_instance_of(RubyLsp::Result, result)
-      refute_nil result.response
+      assert 1, result.response.size
+      assert_equal({
+        range: RubyLsp::Interface::Range.new(
+          start: RubyLsp::Interface::Position.new(line: 0, character: 0),
+            # Fails! Actual is line: 19, character: 19??????
+          end: RubyLsp::Interface::Position.new(line: 2, character: 5)
+        ),
+        newText: <<~RUBY
+          s = "hello"
+          puts s
+        RUBY
+      }, result.response.first.to_hash)
     end
   end
 
@@ -35,31 +46,34 @@ class RubyLspAddonTest < UnitTest
 
   # Lifted from here, because we need to override the formatter to "standard" in the test helper:
   # https://github.com/Shopify/ruby-lsp/blob/4c1906172add4d5c39c35d3396aa29c768bfb898/lib/ruby_lsp/test_helper.rb#L20
-  def with_server(source = nil, uri = Kernel.URI("file:///fake.rb"), stub_no_typechecker: false, load_addons: true,
+  def with_server(source = nil, path = "fake.rb", pwd: "test/fixture/ruby_lsp", stub_no_typechecker: false, load_addons: true,
     &block)
-    server = RubyLsp::Server.new(test_mode: true)
-    server.global_state.formatter = "standard" # <-- TODO this should work, right?
-    server.global_state.stubs(:typechecker).returns(false) if stub_no_typechecker
+    Dir.chdir pwd do
+      server = RubyLsp::Server.new(test_mode: true)
+      uri = Kernel.URI(File.join(server.global_state.workspace_path, path))
+      server.global_state.formatter = "standard" # <-- TODO this should work, right?
+      server.global_state.stubs(:typechecker).returns(false) if stub_no_typechecker
 
-    if source
-      server.process_message({
-        method: "textDocument/didOpen",
-        params: {
-          textDocument: {
-            uri: uri,
-            text: source,
-            version: 1
+      if source
+        server.process_message({
+          method: "textDocument/didOpen",
+          params: {
+            textDocument: {
+              uri: uri,
+              text: source,
+              version: 1
+            }
           }
-        }
-      })
-    end
+        })
+      end
 
-    server.global_state.index.index_single(
-      RubyIndexer::IndexablePath.new(nil, uri.to_standardized_path),
-      source
-    )
-    server.load_addons if load_addons
-    block.call(server, uri)
+      server.global_state.index.index_single(
+        RubyIndexer::IndexablePath.new(nil, uri.to_standardized_path),
+        source
+      )
+      server.load_addons if load_addons
+      block.call(server, uri)
+    end
   ensure
     if load_addons
       RubyLsp::Addon.addons.each(&:deactivate)

--- a/test/ruby_lsp_addon_test.rb
+++ b/test/ruby_lsp_addon_test.rb
@@ -1,0 +1,69 @@
+require "ruby_lsp/internal"
+require "test_helper"
+require "ruby_lsp/standard/addon"
+
+class RubyLspAddonTest < UnitTest
+  def setup
+    @addon = RubyLsp::Standard::Addon.new
+    super
+  end
+
+  def test_name
+    assert_equal "Standard Ruby", @addon.name
+  end
+
+  def test_format
+    source = <<~RUBY
+      s = 'hello'
+      puts s
+    RUBY
+    with_server(source) do |server, uri|
+      server.process_message(
+        id: 1,
+        method: "textDocument/formatting",
+        params: {textDocument: {uri: uri}, position: {line: 0, character: 0}}
+      )
+
+      result = server.pop_response
+
+      assert_instance_of(RubyLsp::Result, result)
+      refute_nil result.response
+    end
+  end
+
+  private
+
+  # Lifted from here, because we need to override the formatter to "standard" in the test helper:
+  # https://github.com/Shopify/ruby-lsp/blob/4c1906172add4d5c39c35d3396aa29c768bfb898/lib/ruby_lsp/test_helper.rb#L20
+  def with_server(source = nil, uri = Kernel.URI("file:///fake.rb"), stub_no_typechecker: false, load_addons: true,
+    &block)
+    server = RubyLsp::Server.new(test_mode: true)
+    server.global_state.formatter = "standard" # <-- TODO this should work, right?
+    server.global_state.stubs(:typechecker).returns(false) if stub_no_typechecker
+
+    if source
+      server.process_message({
+        method: "textDocument/didOpen",
+        params: {
+          textDocument: {
+            uri: uri,
+            text: source,
+            version: 1
+          }
+        }
+      })
+    end
+
+    server.global_state.index.index_single(
+      RubyIndexer::IndexablePath.new(nil, uri.to_standardized_path),
+      source
+    )
+    server.load_addons if load_addons
+    block.call(server, uri)
+  ensure
+    if load_addons
+      RubyLsp::Addon.addons.each(&:deactivate)
+      RubyLsp::Addon.addons.clear
+    end
+  end
+end


### PR DESCRIPTION
## Release plan

- [x] Add a Ruby LSP addon as a formatter and a (pull) diagnostic provider
- [x] Add a test for the addon, using a modified test server helper that relies on ruby_lsp internals
- [x] Drop support for Ruby 2.7, so we can test the LSP plugin
- [x] Get CI passing again
- [x] Validate this all works in VS Code with the latest version of Ruby LSP
- [ ] Cut a patch release   

## Background

After talking to @vinistock at Kaigi, I want to take a stab at advertising a working Ruby LSP addon from within the gem so that Ruby LSP users can get standard support without running the LSP themselves (or installing a custom extension, like our [VS Code extension](https://marketplace.visualstudio.com/items?itemName=testdouble.vscode-standard-ruby)

I'm trying and failing to get this end-to-end working in an example app, so I'm trying to take a step back and just get this test passing. The result's response is nil, but (one assumes?) it shouldn't be.  More importantly, `WrapsBuiltinLspStandardizer#run_formatting` isn't being invoked, so my attempts to set the formatter to `standard is probably not working, either.

To replicate the failure, you should be able to run:

```
$ bundle
$ bundle exec m test/ruby_lsp_addon_test.rb
```