### PR TITLE
Remove EOL ruby versions from CI config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby-version: [2.7, '3.0', 3.1, 3.2, 3.3]
+        ruby-version:
+          - '3.1'
+          - '3.2'
+          - '3.3'
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Matches https://github.com/standardrb/standard-rails/pull/42