### PR TITLE
Update ci workflow versions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -45,7 +45,7 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v6
         with:
           reviewers: camilopayan
           commit-message: '[ ${{ steps.date.outputs.date }} ] - Update dependencies'


### PR DESCRIPTION
Should resolve the two node version warnings in output of update task - https://github.com/standardrb/standard/actions/runs/9736076397

There are other deprecations there re: the `set-output` command, and a failure in latest run. May check those out separately.