### PR TITLE
Ensure returned uri from code actions contain a scheme

### DIFF
--- a/lib/standard/lsp/diagnostic.rb
+++ b/lib/standard/lsp/diagnostic.rb
@@ -82,7 +82,7 @@ module Standard
             document_changes: [
               Interface::TextDocumentEdit.new(
                 text_document: Interface::OptionalVersionedTextDocumentIdentifier.new(
-                  uri: @uri.to_s,
+                  uri: ensure_uri_scheme(@uri.to_s).to_s,
                   version: nil
                 ),
                 edits: correctable? ? offense_replacements : []
@@ -113,7 +113,7 @@ module Standard
             document_changes: [
               Interface::TextDocumentEdit.new(
                 text_document: Interface::OptionalVersionedTextDocumentIdentifier.new(
-                  uri: @uri.to_s,
+                  uri: ensure_uri_scheme(@uri.to_s).to_s,
                   version: nil
                 ),
                 edits: line_disable_comment
@@ -162,6 +162,12 @@ module Standard
 
       def correctable?
         !@offense.corrector.nil?
+      end
+
+      def ensure_uri_scheme(uri)
+        uri = URI.parse(uri)
+        uri.scheme = "file" if uri.scheme.nil?
+        uri
       end
     end
   end

--- a/test/standard/runners/lsp_test.rb
+++ b/test/standard/runners/lsp_test.rb
@@ -65,7 +65,7 @@ class Standard::Runners::LspTest < UnitTest
                   edit: {
                     documentChanges: [
                       {
-                        textDocument: {uri: "/path/to/file.rb", version: nil},
+                        textDocument: {uri: "file:///path/to/file.rb", version: nil},
                         edits: [
                           {
                             range: {
@@ -84,7 +84,7 @@ class Standard::Runners::LspTest < UnitTest
                   edit: {
                     documentChanges: [
                       {
-                        textDocument: {uri: "/path/to/file.rb", version: nil},
+                        textDocument: {uri: "file:///path/to/file.rb", version: nil},
                         edits: [
                           {
                             range: {
@@ -120,7 +120,7 @@ class Standard::Runners::LspTest < UnitTest
                   edit: {
                     documentChanges: [
                       {
-                        textDocument: {uri: "/path/to/file.rb", version: nil},
+                        textDocument: {uri: "file:///path/to/file.rb", version: nil},
                         edits: [
                           {
                             range: {
@@ -139,7 +139,7 @@ class Standard::Runners::LspTest < UnitTest
                   edit: {
                     documentChanges: [
                       {
-                        textDocument: {uri: "/path/to/file.rb", version: nil},
+                        textDocument: {uri: "file:///path/to/file.rb", version: nil},
                         edits: [
                           {
                             range: {
@@ -176,7 +176,7 @@ class Standard::Runners::LspTest < UnitTest
                   edit: {
                     documentChanges: [
                       {
-                        textDocument: {uri: "/path/to/file.rb", version: nil},
+                        textDocument: {uri: "file:///path/to/file.rb", version: nil},
                         edits: [
                           {
                             range: {
@@ -196,7 +196,7 @@ class Standard::Runners::LspTest < UnitTest
                   edit: {
                     documentChanges: [
                       {
-                        textDocument: {uri: "/path/to/file.rb", version: nil},
+                        textDocument: {uri: "file:///path/to/file.rb", version: nil},
                         edits: [
                           {
                             range: {


### PR DESCRIPTION
Using Neovim 0.10 with the ruby-lsp plugin, standard returns code actions to allow for quick fixes. They were returning the uri without the scheme, and that caused neovim to give an error.

To correct for the error, I added an ensure_uri_scheme method to parse the uri and add the "file" scheme if the uri did not include one.

Example of the erorr:
<img width="1896" alt="image" src="https://github.com/user-attachments/assets/e50853ea-f38c-415e-b6db-ebe7aa0ef69e">

Edit: Updated tests to use new file type uri in return.