### PR TITLE
Rake Clean

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
 require "bundler/gem_tasks"
+require "rake/clean"
 require "rake/testtask"
 require_relative "lib/standard/rake"
+
+CLOBBER.include "*.gem"
 
 Rake::TestTask.new(:test) do |t|
   t.warning = false

--- a/Rakefile
+++ b/Rakefile
@@ -5,9 +5,9 @@ require_relative "lib/standard/rake"
 
 CLOBBER.include "*.gem"
 
+task default: [:test, "standard:fix"]
+
 Rake::TestTask.new(:test) do |t|
   t.warning = false
   t.test_files = FileList["test/**/*_test.rb"]
 end
-
-task default: [:test, "standard:fix"]


### PR DESCRIPTION
Bundler's built-in rake tasks add pkg/* to rake's CLOBBER list
(so `rake clobber` removes them).
That's great for .gem that are created via `rake build` because bundler's rake task writes the .gem to pkg/.
However, by default if you run `gem build` instead of `rake build`, you'll end up with the .gem written in the root (next to where the .gemspec is).
This adds *.gem to rake's `CLOBBER` list so that `rake clobber` will properly clean any built gems regardless if they were built via `rake` or `gem`.

(It also moves the default task to the top of the file rather than the bottom.
That's the conventional location inherited from `make` whose default task is _automatically_ the first listed target.)
