### PR TITLE
Add range formatting method to the formatter add-on

### DIFF
--- a/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
+++ b/lib/ruby_lsp/standard/wraps_built_in_lsp_standardizer.rb
@@ -20,6 +20,13 @@ module RubyLsp
         @standardizer.offenses(uri_to_path(uri), document.source, document.encoding)
       end
 
+      def run_range_formatting(_uri, _partial_source, _base_indentation)
+        # Not yet supported. Should return the formatted version of `partial_source` which is a partial selection of the
+        # entire document. For example, it should not try to add a frozen_string_literal magic comment and all style
+        # corrections should start from the `base_indentation`
+        nil
+      end
+
       private
 
       # duplicated from: lib/standard/lsp/routes.rb


### PR DESCRIPTION
We added support for range formatting in the Ruby LSP, which allows users to format a partial selection of the document (it also powers format on paste).

Currently, we only added complete support for Syntax Tree, since it only formats and doesn't have linting rules. For the time being, we can avoid [this error](https://github.com/Shopify/ruby-lsp/issues/2726) by just defining the method and returning `nil`.

It may be possible to support range formatting with Standard, but I'm not sure exactly how. We'd need to understand which corrections apply to the selection and all style/layout corrections have to start with the `base_indentation` instead of considering zero.