### PR TITLE
Proposal: Update rubocop and handles a new cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Updates rubocop to [1.67.0](https://github.com/rubocop/rubocop/releases/tag/v1.67.0)
+
 ## 1.41.1
 
 * Adds a stub method to the Ruby LSP add-on to avoid a potential runtime exception

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     standard (1.41.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.66.0)
+      rubocop (~> 1.67.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.5)
 
@@ -13,7 +13,7 @@ GEM
   specs:
     ast (2.4.2)
     docile (1.4.0)
-    json (2.6.3)
+    json (2.7.4)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
     logger (1.6.0)
@@ -23,18 +23,18 @@ GEM
     method_source (1.0.0)
     minitest (5.20.0)
     mutex_m (0.2.0)
-    parallel (1.23.0)
+    parallel (1.26.3)
     parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
     prism (0.30.0)
-    racc (1.7.1)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (13.0.6)
     rbs (3.5.2)
       logger
-    regexp_parser (2.8.2)
-    rubocop (1.66.1)
+    regexp_parser (2.9.2)
+    rubocop (1.67.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -68,7 +68,7 @@ GEM
     standard-performance (1.5.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.22.0)
-    unicode-display_width (2.5.0)
+    unicode-display_width (2.6.0)
 
 PLATFORMS
   ruby

--- a/config/base.yml
+++ b/config/base.yml
@@ -1,9 +1,9 @@
 Bundler/DuplicatedGem:
   Enabled: true
   Include:
-    - '**/*.gemfile'
-    - '**/Gemfile'
-    - '**/gems.rb'
+    - "**/*.gemfile"
+    - "**/Gemfile"
+    - "**/gems.rb"
 
 Bundler/DuplicatedGroup:
   Enabled: false
@@ -20,9 +20,9 @@ Bundler/GemVersion:
 Bundler/InsecureProtocolSource:
   Enabled: true
   Include:
-    - '**/*.gemfile'
-    - '**/Gemfile'
-    - '**/gems.rb'
+    - "**/*.gemfile"
+    - "**/Gemfile"
+    - "**/gems.rb"
 
 Bundler/OrderedGems:
   Enabled: false
@@ -42,7 +42,7 @@ Gemspec/DevelopmentDependencies:
 Gemspec/DuplicatedAssignment:
   Enabled: true
   Include:
-    - '**/*.gemspec'
+    - "**/*.gemspec"
 
 Gemspec/OrderedDependencies:
   Enabled: false
@@ -243,6 +243,7 @@ Layout/InitialIndentation:
 
 Layout/LeadingCommentSpace:
   Enabled: true
+  AllowRBSInlineAnnotation: true
 
 Layout/LeadingEmptyLines:
   Enabled: true
@@ -510,6 +511,9 @@ Lint/DuplicateRequire:
   Enabled: true
 
 Lint/DuplicateRescueException:
+  Enabled: true
+
+Lint/DuplicateSetElement:
   Enabled: true
 
 Lint/EachWithObjectArgument:
@@ -1177,7 +1181,7 @@ Style/EvenOdd:
   Enabled: false
 
 Style/ExactRegexpMatch:
-    Enabled: true
+  Enabled: true
 Style/ExpandPathArguments:
   Enabled: false
 
@@ -1495,11 +1499,11 @@ Style/PercentLiteralDelimiters:
   Enabled: true
   PreferredDelimiters:
     default: ()
-    '%i': '[]'
-    '%I': '[]'
-    '%r': '{}'
-    '%w': '[]'
-    '%W': '[]'
+    "%i": "[]"
+    "%I": "[]"
+    "%r": "{}"
+    "%w": "[]"
+    "%W": "[]"
 
 Style/PercentQLiterals:
   Enabled: false

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.add_dependency "rubocop", "~> 1.66.0"
+  spec.add_dependency "rubocop", "~> 1.67.0"
 
   spec.add_dependency "lint_roller", "~> 1.0"
   spec.add_dependency "standard-custom", "~> 1.0.0"


### PR DESCRIPTION
Since v1.67.0, the `AllowRBSInlineAnnotation` config option has been added to the `Layout/LeadingCommentSpace` cop.
It is necessary to annotate types in Ruby code via [RBS::Inline](https://github.com/soutaro/rbs-inline). RBS::Inline is a pilot project of [ruby/rbs](https://github.com/ruby/rbs) and is planned to be merged into ruby/rbs.

Could you update rubocop to v1.67.0 and enable the `AllowRBSInlineAnnotation` option, please?