### PR TITLE
Version and style sync across `standard-` repos/gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
     method_source (1.0.0)
-    minitest (5.20.0)
+    minitest (5.25.1)
     mutex_m (0.2.0)
     parallel (1.23.0)
     parser (3.3.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     minitest (5.20.0)
     mutex_m (0.2.0)
     parallel (1.23.0)
-    parser (3.3.5.0)
+    parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
     prism (0.30.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
+    simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     sorbet-runtime (0.5.11481)
     standard-custom (1.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,4 +85,4 @@ DEPENDENCIES
   standard!
 
 BUNDLED WITH
-   2.4.12
+   2.5.23

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -1,6 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "standard/version"
+require_relative "lib/standard/version"
 
 Gem::Specification.new do |spec|
   spec.name = "standard"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 begin
   require "simplecov"
   SimpleCov.start do
-    add_filter "vendor"
+    load_profile "test_frameworks"
   end
 rescue LoadError
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 begin
   require "simplecov"
   SimpleCov.start do


### PR DESCRIPTION
Background: https://github.com/standardrb/standard/pull/657#issuecomment-2462279165

With that version/approach doc merged and PRs either merged/approved for the gemspec-level syncing, I did a pass across the group for some dependency/style consistency as well. Instead of opening six PRs across all repos all at once, I'll start with just this one, sort out any concerns, then open the rest including only things we actually want to solve.

Notes on this one, with remarks about how other repos are same or not...

- Some repos had deprecation notices on various gems -- generally speaking the gem bumps for minitest, parser, bundler itself, etc -- are all bumped just to silence those warnings. I'm optimizing for "tests and lints pass and everything is quiet on latest ruby" in these scenarios.
- In this repo, bump simplecov version to latest - in other repos, add latest simplecov with matching config.
- Every other repo pulls in the version in the gemspec via `require_relative` except this one. I suspect that's just a historical artifact of when they were all generated? Update this one to match.
- In test_helper, match other repo style with `__dir__` instead of `__FILE__` (again assuming this is historical accident)
- The switch to simplecov `test_frameworks` profile successfully ignores the "test" dir, which was previously included in the coverage report.

Still to do:

- In the coverage report output, I noticed that a lot of files are missing ... this is almost definitely a load order interaction of minitest, simplecov, bundler, gemspec, etc. I started to go down the path of working on that, but I wanted to keep this PR to hopefully relatively unobjectionable stuff. Will check that out separately.
- I made a point in all repos to NOT contemplate/bump any of the rules-definining rubocop interactions, but only bump local-dev-facing dependencies (ie, use latest standard for local linting). There's only one spot where I hit deprecation noise related to that decision (in sorbet) - will leave note on that PR when I get to that repo.

Let me know if this is easier processed chopped up smaller - commits are tiny and would be easy to pull out if desired.
