### PR TITLE
Update Rubocop to v1.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-## 1.41.2
-
-* Updates rubocop to [1.68](https://github.com/rubocop/rubocop/releases/tag/v1.68)
+* Updates rubocop to [1.68.0]https://github.com/rubocop/rubocop/tree/v1.68.0)
+* Inherit from `RuboCop::Cop::Base` fixing deprecation warnings.
+* Add new cops
 
 ## 1.41.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.41.2
+
+* Updates rubocop to [1.68](https://github.com/rubocop/rubocop/releases/tag/v1.68)
+
 ## 1.41.1
 
 * Adds a stub method to the Ruby LSP add-on to avoid a potential runtime exception

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     standard (1.41.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.66.0)
+      rubocop (~> 1.68.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.5)
 
@@ -34,7 +34,7 @@ GEM
     rbs (3.5.2)
       logger
     regexp_parser (2.8.2)
-    rubocop (1.66.1)
+    rubocop (1.68.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)

--- a/config/base.yml
+++ b/config/base.yml
@@ -512,6 +512,9 @@ Lint/DuplicateRequire:
 Lint/DuplicateRescueException:
   Enabled: true
 
+Lint/DuplicateSetElement:
+  Enabled: false
+
 Lint/EachWithObjectArgument:
   Enabled: true
 
@@ -798,6 +801,9 @@ Lint/TripleQuotes:
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
 
+Lint/UnescapedBracketInRegexp:
+  Enabled: false
+
 Lint/UnexpectedBlockArity:
   Enabled: false
 
@@ -980,6 +986,9 @@ Style/Alias:
   Enabled: true
   EnforcedStyle: prefer_alias_method
 
+Style/AmbiguousEndlessMethodDefinition:
+  Enabled: false
+
 Style/AndOr:
   Enabled: true
 
@@ -1015,6 +1024,9 @@ Style/BeginBlock:
   Enabled: true
 
 Style/BisectedAttrAccessor:
+  Enabled: false
+
+Style/BitwisePredicate:
   Enabled: false
 
 Style/BlockComments:
@@ -1062,6 +1074,9 @@ Style/ColonMethodCall:
 
 Style/ColonMethodDefinition:
   Enabled: true
+
+Style/CombinableDefined:
+  Enabled: false
 
 Style/CombinableLoops:
   Enabled: false
@@ -1288,6 +1303,9 @@ Style/InvertibleUnlessCondition:
   Enabled: false
 
 Style/IpAddresses:
+  Enabled: false
+
+Style/KeywordArgumentsMerging:
   Enabled: false
 
 Style/KeywordParametersOrder:
@@ -1654,6 +1672,9 @@ Style/SafeNavigation:
     - presence
     - try
     - try!
+
+Style/SafeNavigationChainLength:
+  Emabled: false
 
 Style/Sample:
   Enabled: true

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.add_dependency "rubocop", "~> 1.66.0"
+  spec.add_dependency "rubocop", "~> 1.68.0"
 
   spec.add_dependency "lint_roller", "~> 1.0"
   spec.add_dependency "standard-custom", "~> 1.0.0"

--- a/test/fixture/extend_config/bananas.rb
+++ b/test/fixture/extend_config/bananas.rb
@@ -1,7 +1,7 @@
 module RuboCop
   module Cop
     module Bananas
-      class BananasOnly < Cop
+      class BananasOnly < Base
         def on_lvasgn(node)
           name, = *node
 

--- a/test/fixture/extend_config/betterment.rb
+++ b/test/fixture/extend_config/betterment.rb
@@ -1,7 +1,7 @@
 module RuboCop
   module Cop
     module Betterment
-      class UnscopedFind < Cop
+      class UnscopedFind < Base
       end
     end
   end

--- a/test/fixture/plugins/project/lib/banana/banana_bomb.rb
+++ b/test/fixture/plugins/project/lib/banana/banana_bomb.rb
@@ -2,7 +2,7 @@
 module RuboCop
   module Cop
     module Bananas
-      class BananaBomb < Cop
+      class BananaBomb < Base
         def on_class(node)
           add_offense(node, message: "🍌💣 - Better ignore me!")
         end

--- a/test/fixture/plugins/project/lib/banana/bananas.rb
+++ b/test/fixture/plugins/project/lib/banana/bananas.rb
@@ -1,7 +1,7 @@
 module RuboCop
   module Cop
     module Bananas
-      class BananasOnly < Cop
+      class BananasOnly < Base
         def on_lvasgn(node)
           # cracks me up that we have to disable this cop inside itself
           name, = *node # standard:disable Bananas/BananasOnly

--- a/test/standard/plugin/merges_plugins_into_rubocop_config_test.rb
+++ b/test/standard/plugin/merges_plugins_into_rubocop_config_test.rb
@@ -53,16 +53,16 @@ class Standard::Plugin::MergesPluginsIntoRubocopConfigTest < UnitTest
 
   module RuboCop::Cop
     module Fake
-      class Things < RuboCop::Cop::Cop
+      class Things < RuboCop::Cop::Base
       end
 
-      class Stuff < RuboCop::Cop::Cop
+      class Stuff < RuboCop::Cop::Base
       end
 
-      class Junk < RuboCop::Cop::Cop
+      class Junk < RuboCop::Cop::Base
       end
 
-      class Crap < RuboCop::Cop::Cop
+      class Crap < RuboCop::Cop::Base
       end
     end
   end


### PR DESCRIPTION
This Pull Request updates Rubcop to v1.68

When you are already on [Psych v5.2.0](https://github.com/ruby/psych/tree/v5.2.0) in your Gemfile.lock you will see errors with Rubocop < 1.68 (for example when using Standard auto-linter or using the VSCode plugin which currently times out when you activate format-on-save)

This will fix issues with [psych](https://github.com/ruby/psych) which removed a require on [stringio](https://github.com/ruby/stringio) in ruby/psych#686 

RuboCop relies on that so it has been added in the latest version. 

See 
https://github.com/rubocop/rubocop/pull/11060#issuecomment-2467457040
https://github.com/standardrb/standard/pull/656#issuecomment-2468839945

