### PR TITLE
fix `emabled` typo in Style/SafeNavigationChainLength

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1674,7 +1674,7 @@ Style/SafeNavigation:
     - try!
 
 Style/SafeNavigationChainLength:
-  Emabled: false
+  Enabled: false
 
 Style/Sample:
   Enabled: true


### PR DESCRIPTION
Fixes a typo in the enabled flag in the 1.42.0 release

closes #662