### PR TITLE
Add test for loading config without warnings

### DIFF
--- a/test/standard/base_test.rb
+++ b/test/standard/base_test.rb
@@ -34,6 +34,13 @@ class Standard::BaseTest < UnitTest
     assert_equal expected, actual, "Cop names should be alphabetized! (See this script to do it for you: https://github.com/standardrb/standard/pull/222#issue-744335213 )"
   end
 
+  def test_configuration_loads_without_warnings
+    rules = YAML.load_file(BASE_CONFIG)
+    config = RuboCop::Config.new(rules, BASE_CONFIG)
+
+    assert_silent { config.check }
+  end
+
   private
 
   def to_indented_yaml(cop_hash, without_keys = [])


### PR DESCRIPTION
Background: https://github.com/standardrb/standard/pull/663#issuecomment-2480751535

This works in the sense that if I re-create that typo this test fails, and if I leave the typo fixed this passes, so it presumably would have caught that issue.

I'm not super-familiar with rubocop internals, and am very open to feedback here on more elegǎnt way to capture this. I was expecting to be able to either have a validation object with an activemodel-style `errors` array to assert against, and/or be able to just let this run and have the `ValidationError` be raised - but I think that's swallowed either somewhere within rubocop or somewhere in test harness.