### PR TITLE
Adds Ruby 3.4 to the list of tested rubies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ruby-version:
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Also removes Ruby 3.0 which is EOL.