### PR TITLE
Allow adjacent oneline method definitions

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -132,7 +132,7 @@ Layout/EmptyLineAfterMultilineCondition:
 
 Layout/EmptyLineBetweenDefs:
   Enabled: true
-  AllowAdjacentOneLineDefs: false
+  AllowAdjacentOneLineDefs: true
   NumberOfEmptyLines: 1
 
 Layout/EmptyLines:


### PR DESCRIPTION
The purpose of oneline methods is a terser format for simple methods, similar to defining variables.

This rule change allows oneline methods to be grouped more-closely together, just as you might group variables to convey meaning. This also accomplishes terser class definitions that don't have mandatory double-spacing between oneline methods.

This permits code like:
```ruby
def one = "one"
def two = "two"

def number? = true
def animal? = false
```

Fixes #695 