### PR TITLE
Disable `Lint/UselessConstantScoping`

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -864,7 +864,7 @@ Lint/UselessAssignment:
   Enabled: true
 
 Lint/UselessConstantScoping:
-  Enabled: true
+  Enabled: false
 
 Lint/UselessDefined:
   Enabled: true


### PR DESCRIPTION
Sometimes having constants right next to where they're used makes sense. The alternatives are dragging them to the top of the file where they make no sense out of context.

Fixes #703