### PR TITLE
Allow RBS inline annotation

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -243,6 +243,7 @@ Layout/InitialIndentation:
 
 Layout/LeadingCommentSpace:
   Enabled: true
+  AllowRBSInlineAnnotation: true
 
 Layout/LeadingEmptyLines:
   Enabled: true


### PR DESCRIPTION
This PR add support for RBS in-line annotations.

It replaces #656 which did that but also updated rubocop and had unrelated
changes.  Rubocop was updated to a compatible version with #659, so we just
have to turn on the corresponding option of the rubocop check.
