### PR TITLE
Rubocop YAML schema

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/standard.json
+
+%YAML 1.1
+---
 ruby_version: 3.0
 ignore:
   - tmp/**/*

--- a/config/base.yml
+++ b/config/base.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=../../rubyschema/dist/rubocop.json
+
+%YAML 1.1
+---
 Bundler/DuplicatedGem:
   Enabled: true
   Include:

--- a/config/base.yml
+++ b/config/base.yml
@@ -1231,7 +1231,7 @@ Style/EvenOdd:
   Enabled: false
 
 Style/ExactRegexpMatch:
-    Enabled: true
+  Enabled: true
 Style/ExpandPathArguments:
   Enabled: false
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 AllCops:
   TargetRubyVersion: 3.0
   Exclude: []

--- a/config/ruby-1.8.yml
+++ b/config/ruby-1.8.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 inherit_from: ./ruby-1.9.yml
 
 Style/HashSyntax:

--- a/config/ruby-1.9.yml
+++ b/config/ruby-1.9.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 inherit_from: ./ruby-2.0.yml
 
 Style/Encoding:

--- a/config/ruby-2.0.yml
+++ b/config/ruby-2.0.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 inherit_from: ./ruby-2.1.yml
 
 AllCops:

--- a/config/ruby-2.1.yml
+++ b/config/ruby-2.1.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 inherit_from: ./ruby-2.2.yml
 
 AllCops:

--- a/config/ruby-2.2.yml
+++ b/config/ruby-2.2.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 inherit_from: ./ruby-2.3.yml
 
 AllCops:

--- a/config/ruby-2.3.yml
+++ b/config/ruby-2.3.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 inherit_from: ./ruby-2.4.yml
 
 AllCops:

--- a/config/ruby-2.4.yml
+++ b/config/ruby-2.4.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 inherit_from: ./ruby-2.5.yml
 
 AllCops:

--- a/config/ruby-2.5.yml
+++ b/config/ruby-2.5.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 inherit_from: ./ruby-2.6.yml
 
 AllCops:

--- a/config/ruby-2.6.yml
+++ b/config/ruby-2.6.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 inherit_from: ./ruby-2.7.yml
 
 AllCops:

--- a/config/ruby-2.7.yml
+++ b/config/ruby-2.7.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 inherit_from: ./ruby-3.0.yml
 
 AllCops:

--- a/config/ruby-3.0.yml
+++ b/config/ruby-3.0.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 inherit_from: ./ruby-3.1.yml
 
 AllCops:

--- a/config/ruby-3.1.yml
+++ b/config/ruby-3.1.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 inherit_from: ./ruby-3.2.yml
 
 AllCops:

--- a/config/ruby-3.2.yml
+++ b/config/ruby-3.2.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 inherit_from: ./ruby-3.3.yml
 
 AllCops:

--- a/config/ruby-3.3.yml
+++ b/config/ruby-3.3.yml
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
+%YAML 1.1
+---
 inherit_from: ./base.yml
 
 AllCops:


### PR DESCRIPTION
I’m writing a comprehensive schema for Rubocop in a new project called [Ruby Schema](https://github.com/joeldrapper/rubyschema). The goal of this project is to provide schemas for popular Ruby gems that use YAML configuration files.

The [YAML Language Server](https://github.com/redhat-developer/yaml-language-server) uses these schemas to provide auto-complete, hover documentation and validation. It’s available in loads of text editors and it’s installed by default in [Zed](https://zed.dev). Here’s an example from standard.

<img width="937" alt="Screenshot 2025-06-12 at 11 02 04" src="https://github.com/user-attachments/assets/4c46d21b-bc25-430c-ab32-0e64e8c15b85" />

The Rubocop schema is not finished yet — I’m writing this by hand! — but it is designed to allow for unknown cops so it’s already compatible with Standard’s configs.

It currently provides auto-complete for:

1. top-level configuration,
2. AllCops,
3. departments,
4. generic (shared) cop configuration, and
5. specific cop configuration for Bundler, Gemspec and up to the migration cops (still have naming, security and style to complete).

It’s still a very new project, I only started it yesterday so I understand any reluctance to merge this, but I wanted to at least raise awareness and invite feedback from the standard community.

❤️