### PR TITLE
Update to Rubocop 1.79.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem "bundler"
 gem "minitest", "~> 5.25"
-gem "rake", "~> 13.0"
+gem "rake", "~> 13.3"
 gem "m"
 gem "mutex_m"
 gem "ruby-lsp"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     standard (1.50.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.75.5)
+      rubocop (~> 1.79.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.8)
 
@@ -34,7 +34,7 @@ GEM
     rbs (3.6.1)
       logger
     regexp_parser (2.9.3)
-    rubocop (1.75.5)
+    rubocop (1.79.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -42,10 +42,11 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.44.0, < 2.0)
+      rubocop-ast (>= 1.46.0, < 2.0)
       ruby-progressbar (~> 1.7)
+      tsort (>= 0.2.0)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.44.0)
+    rubocop-ast (1.46.0)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     rubocop-performance (1.25.0)
@@ -69,6 +70,7 @@ GEM
     standard-performance (1.8.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.25.0)
+    tsort (0.2.0)
     unicode-display_width (2.5.0)
 
 PLATFORMS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
   specs:
     ast (2.4.2)
     docile (1.4.0)
-    json (2.6.3)
+    json (2.13.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -30,7 +30,7 @@ GEM
     prism (1.4.0)
     racc (1.7.1)
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.3.0)
     rbs (3.6.1)
       logger
     regexp_parser (2.9.3)
@@ -80,7 +80,7 @@ DEPENDENCIES
   m
   minitest (~> 5.25)
   mutex_m
-  rake (~> 13.0)
+  rake (~> 13.3)
   ruby-lsp
   simplecov
   standard!

--- a/config/base.yml
+++ b/config/base.yml
@@ -975,7 +975,7 @@ Naming/MethodName:
 Naming/MethodParameterName:
   Enabled: false
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: false
 
 Naming/RescuedExceptionsVariableName:

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.add_dependency "rubocop", "~> 1.75.5"
+  spec.add_dependency "rubocop", "~> 1.79.0"
 
   spec.add_dependency "lint_roller", "~> 1.0"
   spec.add_dependency "standard-custom", "~> 1.0.0"


### PR DESCRIPTION
Updates Rubocop to 1.79.x.

Additional changes

- Updates `rake` and `json` gems to clean up a deprecation warning (`warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.`)
- Updates deprecated "Naming/PredicateName" cop name to "Naming/PredicatePrefix"

TODO

- [ ] Configure new cops