### PR TITLE
Remove devdep version specs from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,15 +3,14 @@ source "https://rubygems.org"
 gemspec
 
 gem "bundler"
-gem "minitest", "~> 5.25"
-gem "rake", "~> 13.3"
 gem "m"
+gem "minitest"
 gem "mutex_m"
+gem "rake"
 gem "ruby-lsp"
+gem "simplecov"
 
 # You may want to run these off path locally:
 # gem "lint_roller", path: "../lint_roller"
 # gem "standard-custom", path: "../standard-custom"
 # gem "standard-performance", path: "../standard-performance"
-
-gem "simplecov"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,9 +78,9 @@ PLATFORMS
 DEPENDENCIES
   bundler
   m
-  minitest (~> 5.25)
+  minitest
   mutex_m
-  rake (~> 13.3)
+  rake
   ruby-lsp
   simplecov
   standard!


### PR DESCRIPTION
Version spec pinning dates back to their addition to the Gemfile. The version specs shouldn't really be necessary.

(Simplecov was separate because it used to be guarded with a ruby version conditional. That's no longer necessary so it shouldn't be isolated on its own.)