### PR TITLE
Disable `EmptyLinesAfterModuleInclusion`

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -142,7 +142,7 @@ Layout/EmptyLines:
   Enabled: true
 
 Layout/EmptyLinesAfterModuleInclusion:
-  Enabled: true
+  Enabled: false
 
 Layout/EmptyLinesAroundAccessModifier:
   Enabled: true


### PR DESCRIPTION
When using [concern-heavy patterns](https://dev.37signals.com/good-concerns), there shouldn't have to be an empty line between every include statement, especially since Standard already only allows one module per include statement (can't do `include One, Two, Three`).