### PR TITLE
Change required rubocop version: ~> 1.81.7 to ~> 1.82.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Updates rubocop to [1.82.1](https://github.com/rubocop/rubocop/tree/v1.82.1)
+
 ## 1.52.0
 
 * Updates rubocop to [1.81.7](https://github.com/rubocop/rubocop/tree/v1.81.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     standard (1.52.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.81.7)
+      rubocop (~> 1.82.1)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.8)
 
@@ -32,7 +32,7 @@ GEM
     rbs (3.6.1)
       logger
     regexp_parser (2.11.3)
-    rubocop (1.81.7)
+    rubocop (1.82.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -40,7 +40,7 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.47.1, < 2.0)
+      rubocop-ast (>= 1.48.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.48.0)

--- a/config/base.yml
+++ b/config/base.yml
@@ -1454,6 +1454,9 @@ Style/MixinUsage:
 Style/ModuleFunction:
   Enabled: false
 
+Style/ModuleMemberExistenceCheck:
+  Enabled: false
+
 Style/MultilineBlockChain:
   Enabled: false
 

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.add_dependency "rubocop", "~> 1.81.7"
+  spec.add_dependency "rubocop", "~> 1.82.1"
 
   spec.add_dependency "lint_roller", "~> 1.0"
   spec.add_dependency "standard-custom", "~> 1.0.0"


### PR DESCRIPTION
In order to use standard gem in ruby 4.0, I want to make it possible to use rubocop 1.82.0 or higher, which supports ruby 4.0. Therefore, following past conventions, I have proposed upgrading the rubocop version here. 

- Resolve https://github.com/standardrb/standard/issues/777

I referred to the following PR, as it seems to be where the previous change was implemented. 

- https://github.com/standardrb/standard/pull/767

While `~> 1.82.0` would have been sufficient, the latest rubocop version currently released is 1.82.1. Since previous version updates seem to have been based on setting the requirement to the latest version available at the time, I have set it to `~> 1.82.1` for this instance.

FYI: It looks like there's another related PR:

- https://github.com/standardrb/standard/pull/776

It appeared that this Dependabot PR was causing CI to fail because new Style/ModuleMemberExistenceCheck cop was added in version 1.82.0, so I have included the necessary fix in this PR. Following past conventions, I simply disabled it this time.