### PR TITLE
Decrease depbot frequency for GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,5 @@ updates:
     schedule: { interval: weekly, day: monday }
   - package-ecosystem: github-actions
     directory: "/"
-    schedule: { interval: weekly }
+    schedule: { interval: monthly }
+    cooldown: { default-days: 14 }


### PR DESCRIPTION
In addition to checking less frequently (for github-actions) from weekly
to monthly; also add a 2-week cooldown. This should help batch any
follow-on patch releases.

Notably, security updates are _not_ affected by cooldown so we should
(hopefully) not be prevented from any security release that happens
within the cooldown window.
