### PR TITLE
Fix CI failures: configure new RuboCop 1.85/1.86 cops and fix genignore test

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1620,7 +1620,7 @@ Style/ParenthesesAroundCondition:
   AllowInMultilineConditions: false
 
 Style/PartitionInsteadOfDoubleSelect:
-  Enabled: true
+  Enabled: false
 
 Style/PercentLiteralDelimiters:
   Enabled: true

--- a/config/base.yml
+++ b/config/base.yml
@@ -484,6 +484,9 @@ Lint/ConstantResolution:
 Lint/CopDirectiveSyntax:
   Enabled: true
 
+Lint/DataDefineOverride:
+  Enabled: true
+
 Lint/Debugger:
   Enabled: true
 
@@ -851,6 +854,9 @@ Lint/UnreachableCode:
 
 Lint/UnreachableLoop:
   Enabled: false
+
+Lint/UnreachablePatternBranch:
+  Enabled: true
 
 Lint/UnusedBlockArgument:
   Enabled: false
@@ -1278,6 +1284,9 @@ Style/FileEmpty:
 Style/FileNull:
   Enabled: true
 
+Style/FileOpen:
+  Enabled: true
+
 Style/FileRead:
   Enabled: true
 
@@ -1417,6 +1426,9 @@ Style/MapCompactWithConditionalBlock:
   Enabled: true
 
 Style/MapIntoArray:
+  Enabled: false
+
+Style/MapJoin:
   Enabled: false
 
 Style/MapToHash:
@@ -1575,6 +1587,9 @@ Style/NumericPredicate:
 Style/ObjectThen:
   Enabled: false
 
+Style/OneClassPerFile:
+  Enabled: false
+
 Style/OneLineConditional:
   Enabled: true
 
@@ -1604,6 +1619,9 @@ Style/ParenthesesAroundCondition:
   AllowSafeAssignment: true
   AllowInMultilineConditions: false
 
+Style/PartitionInsteadOfDoubleSelect:
+  Enabled: true
+
 Style/PercentLiteralDelimiters:
   Enabled: true
   PreferredDelimiters:
@@ -1620,6 +1638,9 @@ Style/PercentQLiterals:
 Style/PerlBackrefs:
   Enabled: false
 
+Style/PredicateWithKind:
+  Enabled: true
+
 Style/PreferredHashMethods:
   Enabled: false
 
@@ -1635,6 +1656,9 @@ Style/RaiseArgs:
 
 Style/RandomWithOffset:
   Enabled: true
+
+Style/ReduceToHash:
+  Enabled: false
 
 Style/RedundantArgument:
   Enabled: false
@@ -1705,6 +1729,9 @@ Style/RedundantInterpolationUnfreeze:
 Style/RedundantLineContinuation:
   Enabled: true
 
+Style/RedundantMinMaxBy:
+  Enabled: true
+
 Style/RedundantParentheses:
   Enabled: true
 
@@ -1745,6 +1772,9 @@ Style/RedundantSortBy:
 Style/RedundantStringEscape:
   Enabled: true
 
+Style/RedundantStructKeywordInit:
+  Enabled: false
+
 Style/RegexpLiteral:
   Enabled: false
 
@@ -1782,6 +1812,12 @@ Style/SafeNavigationChainLength:
 
 Style/Sample:
   Enabled: true
+
+Style/SelectByKind:
+  Enabled: false
+
+Style/SelectByRange:
+  Enabled: false
 
 Style/SelectByRegexp:
   Enabled: false
@@ -1878,6 +1914,9 @@ Style/SymbolLiteral:
 
 Style/SymbolProc:
   Enabled: false
+
+Style/TallyMethod:
+  Enabled: true
 
 Style/TernaryParentheses:
   Enabled: true

--- a/test/standard/runners/genignore_test.rb
+++ b/test/standard/runners/genignore_test.rb
@@ -25,8 +25,10 @@ class Standard::Runners::GenignoreTest < UnitTest
     assert File.exist?("dont_call_it_tmp/genignore_test/.standard_todo.yml")
 
     todo = YAML.load_file("dont_call_it_tmp/genignore_test/.standard_todo.yml")
+    assert todo["ignore"]
     # RuboCop 1.85+ reports paths relative to the process CWD rather than Dir.chdir,
-    # so normalize to basenames for version compatibility
+    # so normalize to basenames for version compatibility.
+    # TODO: remove basename normalization once the rubocop floor is >= 1.85.
     normalized = {"ignore" => todo["ignore"].map { |h| h.transform_keys { |k| File.basename(k) } }}
     expected_yaml = {"ignore" => [
       {"errors_one.rb" => ["Lint/AssignmentInCondition"]},

--- a/test/standard/runners/genignore_test.rb
+++ b/test/standard/runners/genignore_test.rb
@@ -14,17 +14,25 @@ class Standard::Runners::GenignoreTest < UnitTest
     FileUtils.cp_r("test/fixture/genignore/.", "dont_call_it_tmp/genignore_test")
 
     Dir.chdir("dont_call_it_tmp/genignore_test") do
-      config = Standard::BuildsConfig.new.call(["--config", "../../config/base.yml"])
+      # Pass explicit file list so RuboCop doesn't scan unrelated files from the project root
+      config = Standard::BuildsConfig.new.call([
+        "--config", "../../config/base.yml",
+        "errors_one.rb", "errors_two.rb", "no_errors.rb"
+      ])
       @subject.call(config)
     end
 
     assert File.exist?("dont_call_it_tmp/genignore_test/.standard_todo.yml")
 
+    todo = YAML.load_file("dont_call_it_tmp/genignore_test/.standard_todo.yml")
+    # RuboCop 1.85+ reports paths relative to the process CWD rather than Dir.chdir,
+    # so normalize to basenames for version compatibility
+    normalized = {"ignore" => todo["ignore"].map { |h| h.transform_keys { |k| File.basename(k) } }}
     expected_yaml = {"ignore" => [
       {"errors_one.rb" => ["Lint/AssignmentInCondition"]},
       {"errors_two.rb" => ["Lint/UselessAssignment"]}
     ]}
-    assert_equal expected_yaml, YAML.load_file("dont_call_it_tmp/genignore_test/.standard_todo.yml")
+    assert_equal expected_yaml, normalized
   ensure
     FileUtils.rm_rf("dont_call_it_tmp")
   end


### PR DESCRIPTION
## Summary

Fixes the two CI failures in #801.

- **`config/base.yml`**: Adds 13 new cops introduced in RuboCop 1.85/1.86 that were in `pending` state, causing the `test_configures_all_rubocop_cops` assertion to fail. Each is set to `Enabled: true` or `false` consistent with how similar cops are configured.
- **`genignore_test.rb`**: RuboCop 1.85+ changed path reporting — when `Dir.chdir` is used, paths are now reported relative to the process CWD rather than the chdir directory. The fix passes an explicit file list so RuboCop doesn't accidentally scan unrelated project files, and normalizes paths to basenames in the assertion for version compatibility. Also asserts `todo["ignore"]` is present before normalizing so a regression fails clearly instead of with `NoMethodError`.

## New cops configured

| Cop | Enabled |
|-----|---------|
| `Lint/DataDefineOverride` | true |
| `Lint/UnreachablePatternBranch` | true |
| `Style/FileOpen` | true |
| `Style/MapJoin` | false |
| `Style/OneClassPerFile` | false |
| `Style/PartitionInsteadOfDoubleSelect` | false |
| `Style/PredicateWithKind` | true |
| `Style/ReduceToHash` | false |
| `Style/RedundantMinMaxBy` | true |
| `Style/RedundantStructKeywordInit` | false |
| `Style/SelectByKind` | false |
| `Style/SelectByRange` | false |
| `Style/TallyMethod` | true |

Happy to adjust any of the enabled/disabled decisions — these are judgment calls based on how similar cops are already configured.