### PR TITLE
Update rubocop to 1.86.1 and standard-performance to 1.9.0

### DIFF
--- a/.claude/skills/rubocop-update/SKILL.md
+++ b/.claude/skills/rubocop-update/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: rubocop-update
+description: Bump RuboCop (and standard-performance if a new version exists) to their latest released versions and open a pull request for the standard gem. Use this skill whenever someone asks to update, bump, or upgrade RuboCop, or when preparing a monthly standard release that tracks a new RuboCop version. Also use it when someone asks what new cops RuboCop shipped and how standard should handle them.
+---
+
+# Monthly RuboCop Update
+
+This skill automates the monthly RuboCop version bump for the `standard` gem. It updates the RuboCop and standard-performance dependencies, discovers new and changed cops, updates the changelog, bumps the standard version, and opens a pull request — leaving yml configuration of new cops as intentional follow-up work.
+
+## Step 1: Determine current and latest versions
+
+Read `standard.gemspec` to extract the current version constraints. The relevant lines look like:
+```ruby
+spec.add_dependency "rubocop", "~> 1.84.0"
+spec.add_dependency "standard-performance", "~> 1.8"
+```
+
+Fetch the latest released versions in parallel from the RubyGems API:
+```
+GET https://rubygems.org/api/v1/gems/rubocop.json
+GET https://rubygems.org/api/v1/gems/standard-performance.json
+```
+Parse the `version` field from each response.
+
+For rubocop: the current pinned minor is `X.Y` from `~> X.Y.0`. If the latest has the same `X.Y`, this is a patch-only update; otherwise it's a minor bump.
+
+For standard-performance: the current pinned minor is `X.Y` from `~> X.Y`. Compare to the latest.
+
+If neither gem has a newer version, stop and tell the user everything is already up to date.
+
+## Step 2: Update the gemspec
+
+In `standard.gemspec`:
+
+- If rubocop has a new version, change its constraint to `"~> NEW_MAJOR.NEW_MINOR.0"`.  
+  Example: `"~> 1.84.0"` → `"~> 1.85.0"`
+- If standard-performance has a new minor version, change its constraint to `"~> NEW_MAJOR.NEW_MINOR"`.  
+  Example: `"~> 1.8"` → `"~> 1.9"`  
+  If standard-performance only has a patch update within the same minor, no gemspec change is needed — the existing pessimistic constraint already allows it.
+
+## Step 3: Update the lockfile
+
+```bash
+bundle update rubocop standard-performance
+```
+
+(If only one gem changed, pass only that gem's name to `bundle update`.)
+
+## Step 4: Bump the standard version
+
+In `lib/standard/version.rb`, bump the version following this convention:
+- Minor bump in rubocop (or standard-performance) → bump standard's minor version
+- Patch-only bump in both → bump standard's patch version
+
+Example: `1.54.0` → `1.55.0` for a rubocop minor update.
+
+Then run `bundle` so Bundler writes the new gem version to `Gemfile.lock`.
+
+## Step 5: Find new and modified cops from the RuboCop changelog
+
+Fetch the RuboCop CHANGELOG:
+```
+GET https://raw.githubusercontent.com/rubocop/rubocop/main/CHANGELOG.md
+```
+
+Find all sections with headers between `## <new_rubocop_version>` and `## <old_rubocop_version>` (there may be multiple intermediate releases if we skipped a version). Within those sections, look for two categories:
+
+**New cops** — lines in `### New features` that introduce a brand-new cop:
+- Pattern: contains "Add new `Cop/Name`" or "new cop `Cop/Name`"
+- Extract: cop name, PR URL, and one-sentence description from the changelog line
+
+**Changed cops** — lines in `### Changes` (not bug fixes) that modify behavior of an existing cop:
+- Extract: cop name, PR URL, and what changed
+
+Ignore `### Bug fixes` entries — those don't require configuration decisions.
+
+If standard-performance also bumped, note it in the PR description but no cop-level changelog parsing is needed for it.
+
+## Step 6: Update CHANGELOG.md
+
+Prepend a new entry at the very top of `CHANGELOG.md`, following the existing format exactly:
+
+```markdown
+## X.Y.Z
+
+* Updates rubocop to [A.B.C](https://github.com/rubocop/rubocop/releases/tag/vA.B.C)
+* Updates standard-performance to [D.E.F](https://github.com/standardrb/standard-performance/releases/tag/vD.E.F)
+
+```
+
+Omit the standard-performance line if it didn't change. Keep every existing line unchanged.
+
+## Step 7: Create a branch, commit, and open a PR
+
+Create a branch named `update-rubocop-A.B.C`.
+
+Stage and commit these files together:
+- `standard.gemspec`
+- `Gemfile.lock`
+- `lib/standard/version.rb`
+- `CHANGELOG.md`
+
+Commit message: `Update rubocop to A.B.C` (include `, standard-performance to D.E.F` if it also changed).
+
+Push the branch and open a PR. Title: **"Update rubocop to A.B.C"** (append `and standard-performance to D.E.F` if applicable).
+
+PR description:
+
+```
+Updates RuboCop from <old> to <new>.
+[If standard-performance changed: Updates standard-performance from <old> to <new>.]
+
+## New cops
+
+These cops were added and need a configuration decision before tests will pass:
+
+| Cop | Description | PR |
+|-----|-------------|-----|
+| `Style/ExampleCop` | One-line description from changelog | [#12345](link) |
+
+## Changed cops
+
+These existing cops had behavioral changes:
+
+| Cop | Change | PR |
+|-----|--------|-----|
+| `Style/ExistingCop` | What changed | [#12346](link) |
+
+---
+
+The `config/` YAML files have not been updated for any of the above cops.
+Tests are expected to fail until those configurations are added in a follow-up.
+```
+
+Omit either table if empty. If there were no new or changed cops, note that in the description instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.55.0
+
+* Updates rubocop to [1.86.1](https://github.com/rubocop/rubocop/releases/tag/v1.86.1)
+* Updates standard-performance to [1.9.0](https://github.com/standardrb/standard-performance/releases/tag/v1.9.0)
+
 ## 1.54.0
 
 * Updates rubocop to [1.84.0](https://github.com/rubocop/rubocop/releases/tag/v1.84.2)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```sh
+# Run all tests and auto-fix standard violations
+./bin/rake
+
+# Run only tests
+./bin/rake test
+
+# Run a single test file
+ruby -Ilib -Itest test/standard/cli_test.rb
+
+# Run standard linter (fix mode)
+./bin/rake standard:fix
+
+# Release the gem
+./bin/rake release
+```
+
+## Architecture
+
+Standard Ruby is a linter/formatter built on top of RuboCop that provides an unconfigurable ruleset. The gem is intentionally opinionated — users cannot change the rules, only ignore violations.
+
+### Request flow
+
+`exe/standardrb` → `Standard::Cli` → `BuildsConfig` → `LoadsRunner` → runner
+
+- **`BuildsConfig`** is the central orchestrator: it resolves `.standard.yml` and `.standard_todo.yml`, loads and merges settings from YAML + CLI args, then builds a `Standard::Config` struct (`runner`, `paths`, `rubocop_options`, `rubocop_config_store`).
+- **`CreatesConfigStore`** builds the `RuboCop::ConfigStore` by composing several single-responsibility objects: `AssignsRubocopYaml`, `SetsTargetRubyVersion`, `ConfiguresIgnoredPaths`, `MergesUserConfigExtensions`, and `Plugin::CombinesPluginConfigs`.
+- **`LoadsRunner`** resolves the correct runner class from `lib/standard/runners/` (`:rubocop`, `:lsp`, `:genignore`, `:help`, `:version`, `:verbose_version`).
+
+### Plugin system
+
+Since v1.28.0, Standard's own rules are loaded as plugins via [lint_roller](https://github.com/standardrb/lint_roller). The `standard` gem bundles `Standard::Base::Plugin` (`lib/standard/base/plugin.rb`), which selects a versioned YAML config from `config/` based on the project's target Ruby version (e.g. `config/ruby-3.3.yml` inherits from `config/base.yml`). Default plugins also include `standard-performance` and `standard-custom` (separate gems).
+
+User-defined plugins are declared in `.standard.yml` under `plugins:` and loaded through `lib/standard/plugin/` — `StandardizesConfiguredPlugins` normalizes the plugin list, `InitializesPlugins` instantiates them, `CombinesPluginConfigs` merges their RuboCop YAML into the config store.
+
+### LSP
+
+`lib/standard/lsp/` provides a built-in LSP server (push diagnostics, formatting). A separate Ruby LSP add-on at `lib/ruby_lsp/standard/addon.rb` hooks into the [ruby-lsp](https://github.com/Shopify/ruby-lsp) ecosystem and supports pull diagnostics and code actions.
+
+### Config files
+
+- `config/base.yml` — the canonical RuboCop rule configuration
+- `config/ruby-X.Y.yml` — per-version overrides that inherit from `base.yml`
+- `.standard.yml` — user project config (ignored globs, plugins, `ruby_version`, etc.)
+- `.standard_todo.yml` — auto-generated per-file ignore list for incremental adoption
+
+### Testing
+
+Tests use Minitest. `test/test_helper.rb` defines `UnitTest < Minitest::Test` with helpers. Test fixtures live in `test/fixture/` and cover CLI behavior, config loading, plugin loading, LSP, and extend_config scenarios. The `test/fixture/**/*` directory is excluded from Standard's own linting (see `.standard.yml`).
+
+### Release process
+
+See `docs/RELEASE.md`. RuboCop dependencies in `standard.gemspec` are pinned to exact versions. Version bump, `bundle`, and CHANGELOG update are committed together with the version string as the commit message before running `./bin/rake release`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 PATH
   remote: .
   specs:
-    standard (1.54.0)
+    standard (1.55.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.84.0)
+      rubocop (~> 1.86.0)
       standard-custom (~> 1.0.0)
-      standard-performance (~> 1.8)
+      standard-performance (~> 1.9)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
     docile (1.4.0)
-    json (2.19.2)
+    json (2.19.5)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -21,8 +21,8 @@ GEM
       rake
     minitest (5.26.1)
     mutex_m (0.3.0)
-    parallel (1.27.0)
-    parser (3.3.10.0)
+    parallel (2.1.0)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     prism (1.9.0)
@@ -31,19 +31,19 @@ GEM
     rake (13.4.2)
     rbs (3.6.1)
       logger
-    regexp_parser (2.11.3)
-    rubocop (1.84.2)
+    regexp_parser (2.12.0)
+    rubocop (1.86.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      parallel (~> 1.10)
+      parallel (>= 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.0)
+    rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-performance (1.26.1)
@@ -86,4 +86,4 @@ DEPENDENCIES
   standard!
 
 BUNDLED WITH
-   2.5.23
+  4.0.10

--- a/lib/standard/version.rb
+++ b/lib/standard/version.rb
@@ -1,3 +1,3 @@
 module Standard
-  VERSION = Gem::Version.new("1.54.0")
+  VERSION = Gem::Version.new("1.55.0")
 end

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.add_dependency "rubocop", "~> 1.84.0"
+  spec.add_dependency "rubocop", "~> 1.86.0"
 
   spec.add_dependency "lint_roller", "~> 1.0"
   spec.add_dependency "standard-custom", "~> 1.0.0"
-  spec.add_dependency "standard-performance", "~> 1.8"
+  spec.add_dependency "standard-performance", "~> 1.9"
 
   # not semver: first three are lsp protocol version, last is patch
   spec.add_dependency "language_server-protocol", "~> 3.17.0.2"


### PR DESCRIPTION
Updates RuboCop from 1.84.0 to 1.86.1.
Updates standard-performance to 1.9.0.

## New cops

These cops were added and need a configuration decision before tests will pass:

| Cop | Description | PR |
|-----|-------------|-----|
| `Lint/DataDefineOverride` | Checks for `Data.define` overriding existing methods. | [#14773](https://github.com/rubocop/rubocop/issues/14773) |
| `Lint/UnreachablePatternBranch` | Checks for unreachable pattern branches in `case` expressions. | [#14925](https://github.com/rubocop/rubocop/pull/14925) |
| `Style/FileOpen` | Checks for `File.open` without a block. | [#14942](https://github.com/rubocop/rubocop/pull/14942) |
| `Style/MapJoin` | Checks for `map { ... }.join` and suggests `map_join` or efficient alternatives. | [#14939](https://github.com/rubocop/rubocop/pull/14939) |
| `Style/OneClassPerFile` | Checks that each file contains only one class definition. | [#14924](https://github.com/rubocop/rubocop/pull/14924) |
| `Style/PartitionInsteadOfDoubleSelect` | Checks for multiple `select` calls that can be replaced with `partition`. | [#14923](https://github.com/rubocop/rubocop/pull/14923) |
| `Style/PredicateWithKind` | Checks for predicate methods used with `kind_of?` or `is_a?`. | [#14811](https://github.com/rubocop/rubocop/pull/14811) |
| `Style/ReduceToHash` | Checks for `reduce` or `inject` used to build a hash. | [#14938](https://github.com/rubocop/rubocop/pull/14938) |
| `Style/RedundantMinMaxBy` | Checks for redundant `min_by` or `max_by` calls. | [#14812](https://github.com/rubocop/rubocop/pull/14812) |
| `Style/RedundantStructKeywordInit` | Checks for redundant `keyword_init: true` in `Struct.new`. | [#13501](https://github.com/rubocop/rubocop/issues/13501) |
| `Style/SelectByKind` | Checks for `select` calls that can be replaced with `grep`. | [#14808](https://github.com/rubocop/rubocop/pull/14808) |
| `Style/SelectByRange` | Checks for `select` calls that can be replaced with range slicing. | [#14810](https://github.com/rubocop/rubocop/pull/14810) |
| `Style/TallyMethod` | Checks for manual tallying logic that can be replaced with `Enumerable#tally`. | [#14922](https://github.com/rubocop/rubocop/pull/14922) |
| `Style/EmptyClassDefinition` | Enforces consistent style for empty classes. | [#14895](https://github.com/rubocop/rubocop/issues/14895) |
| `Style/HashLookupMethod` | Enforces preference between `Hash#[]` and `Hash#fetch`. | [#14977](https://github.com/rubocop/rubocop/issues/14977) |

## Changed cops

These existing cops had behavioral changes:

| Cop | Change | PR |
|-----|--------|-----|
| `Style/OneClassPerFile` | Now excludes `spec/**/*` and `test/**/*` by default. | [#15005](https://github.com/rubocop/rubocop/pull/15005) |
| `Style/RedundantStructKeywordInit` | Disabled by default. | [#15063](https://github.com/rubocop/rubocop/pull/15063) |
| `Style/EndlessMethod` | Updated to consider receivers. | [#14917](https://github.com/rubocop/rubocop/pull/14917) |
| `Style/RedundantInterpolationUnfreeze` | Add support for `String.new` with interpolated strings. | [#14956](https://github.com/rubocop/rubocop/pull/14956) |
| `Style/RedundantParentheses` | Register redundant parentheses around block bodies. | [#14955](https://github.com/rubocop/rubocop/pull/14955) |

---

The `config/` YAML files have not been updated for any of the above cops.
Tests are expected to fail until those configurations are added in a follow-up.
