### PR TITLE
Update rubocop to 1.86.1

### DIFF
--- a/.claude/skills/rubocop-update/SKILL.md
+++ b/.claude/skills/rubocop-update/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: rubocop-update
+description: Bump RuboCop and standard-performance to their latest versions and open a PR. Use this for monthly updates or when tracking new cops.
+---
+
+# RuboCop Update
+
+This skill automates the RuboCop version bump for `standard`. It uses CLI tools for efficiency and consistency with the project's GitHub Actions.
+
+## Step 1: Check for Updates
+
+Identify outdated gems and their versions:
+```bash
+bundle outdated rubocop standard-performance
+```
+Note the **current** and **newest** versions for both gems.
+
+## Step 2: Update Gemspec and Lockfile
+
+Use `sed` to update `standard.gemspec` for any gem with a new minor/patch version.
+Example for RuboCop:
+```bash
+sed -i '/"rubocop"/s/OLD_VERSION/NEW_VERSION/' standard.gemspec
+```
+*Note: RuboCop constraint should be `~> MAJOR.MINOR.0`. standard-performance should be `~> MAJOR.MINOR`.*
+
+Then update the lockfile:
+```bash
+bundle update rubocop standard-performance
+```
+
+## Step 4: Parse RuboCop Changelog
+
+Generate the "New Cops" and "Changed Cops" tables for the PR description:
+```bash
+curl -s https://raw.githubusercontent.com/rubocop/rubocop/main/CHANGELOG.md | \
+  .claude/skills/rubocop-update/scripts/parse_changelog.rb --old OLD_RUBOCOP_VER --new NEW_RUBOCOP_VER > pr_body.md
+```
+
+## Step 5: Evaluate New Rules (Standard Ethos)
+
+For each cop in the "New cops" table, replace the `{RECOMMENDATION}` and `{RATIONALE}` placeholders with a recommendation and a paragraph explaining the rationale.
+
+**Ethos Guidelines (from Standard Ruby):**
+- **Enable if:** It has a **safe autocorrect**, improves readability, encourages modern Ruby, or reduces errors without being niche.
+- **Ignore/Disable if:** It is purely stylistic (bikeshedding), has an unsafe autocorrect, is overly restrictive, or causes high friction/noise for little gain.
+
+**Recommendation Format:**
+- **Recommendation:** `Enable` or `Ignore`.
+- **Rationale:** A concise paragraph explaining how the rule aligns with or deviates from the Standard ethos.
+
+## Step 6: Update CHANGELOG.md
+
+
+Prepend the update note after the `# Changelog` header. Since the standard version is bumped separately, add this under a `## Unreleased` header if it doesn't exist, or at the top of the existing unreleased section:
+```bash
+sed -i '3i\
+\
+## Unreleased\
+\
+* Updates rubocop to [NEW_RUBOCOP_VER](https://github.com/rubocop/rubocop/releases/tag/vNEW_RUBOCOP_VER)\
+* Updates standard-performance to [NEW_PERF_VER](https://github.com/standardrb/standard-performance/releases/tag/vNEW_PERF_VER)' CHANGELOG.md
+```
+*(Adjust the `sed` line number or content if the gem list differs.)*
+
+## Step 5: Create Branch and Commit
+
+```bash
+git checkout -b update-rubocop-NEW_RUBOCOP_VER
+git add standard.gemspec Gemfile.lock CHANGELOG.md
+git commit -m "Update rubocop to NEW_RUBOCOP_VER, standard-performance to NEW_PERF_VER"
+```
+
+## Step 6: Open Pull Request
+
+Prepare the full PR description by prepending the header to `pr_body.md`:
+```bash
+echo -e "Updates RuboCop from OLD_VER to NEW_VER.\nUpdates standard-performance to NEW_PERF_VER.\n\n$(cat pr_body.md)\n\n---\n\nThe \`config/\` YAML files have not been updated for any of the above cops.\nTests are expected to fail until those configurations are added in a follow-up." > pr_full_body.md
+```
+
+Then create the PR:
+```bash
+gh pr create --title "Update rubocop to NEW_RUBOCOP_VER" --body-file pr_full_body.md
+```
+Delete temporary files: `rm pr_body.md pr_full_body.md`.

--- a/.claude/skills/rubocop-update/scripts/parse_changelog.rb
+++ b/.claude/skills/rubocop-update/scripts/parse_changelog.rb
@@ -1,0 +1,90 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: parse_changelog.rb [options]"
+  opts.on("--old VERSION", "Old version (e.g., 1.84.0)") { |v| options[:old] = v }
+  opts.on("--new VERSION", "New version (e.g., 1.86.1)") { |v| options[:new] = v }
+end.parse!
+
+unless options[:old] && options[:new]
+  warn "Error: Missing --old or --new version"
+  exit 1
+end
+
+changelog = STDIN.read
+lines = changelog.lines
+
+new_version_found = false
+relevant_lines = []
+
+# RuboCop versions in CHANGELOG can be "## 1.86.0" or "## [1.86.0]"
+lines.each do |line|
+  if line =~ /^## \[?#{Regexp.escape(options[:new])}\]?/
+    new_version_found = true
+  elsif line =~ /^## \[?#{Regexp.escape(options[:old])}\]?/
+    break if new_version_found
+  end
+  relevant_lines << line if new_version_found
+end
+
+def extract_cops(lines, section_header)
+  cops = []
+  in_section = false
+  lines.each do |line|
+    if line =~ /^### #{section_header}/
+      in_section = true
+    elsif line =~ /^### /
+      in_section = false
+    end
+
+    next unless in_section
+
+    # Formats:
+    # 1. * Add new `Cop/Name` cop. ([#123](url))
+    # 2. * [#123](url): Add new `Cop/Name` cop.
+    # 3. * **Cop/Name**: Description ([#123](url))
+    
+    if line =~ /^\s*\*\s+.*`([^`]+)`.*\[#(\d+)\]\(([^)]+)\):?\s*(.*)$/
+      cops << { name: $1, pr_id: $2, pr_url: $3, description: $4.strip.gsub(/\.$/, '') }
+    elsif line =~ /^\s*\*\s+.*`([^`]+)`.*:?\s*(.*)\s+\(\[#(\d+)\]\(([^)]+)\)\)$/
+      cops << { name: $1, pr_id: $3, pr_url: $4, description: $2.strip.gsub(/\.$/, '') }
+    elsif line =~ /^\s*\*\s+\[#(\d+)\]\(([^)]+)\):\s+.*`([^`]+)`\s*(.*)$/
+      cops << { name: $3, pr_id: $1, pr_url: $2, description: $4.strip.gsub(/\.$/, '') }
+    elsif line =~ /^\s*\*\s+\*\*([^*]+)\*\*:\s*(.*)\s+\(\[#(\d+)\]\(([^)]+)\)\)$/
+      cops << { name: $1, pr_id: $3, pr_url: $4, description: $2.strip.gsub(/\.$/, '') }
+    end
+  end
+  cops.uniq { |c| c[:name] }
+end
+
+new_cops = extract_cops(relevant_lines, "New features")
+changed_cops = extract_cops(relevant_lines, "Changes")
+
+def print_table(title, cops, column_name)
+  return if cops.empty?
+  puts "## #{title}"
+  puts ""
+  if title == "New cops"
+    puts "| Cop | Description | Recommendation | Rationale | PR |"
+    puts "|-----|-------------|----------------|-----------|-----|"
+    cops.each do |cop|
+      desc = cop[:description].empty? ? "No description provided" : cop[:description]
+      # Placeholders for the agent to fill in
+      puts "| `#{cop[:name]}` | #{desc} | {RECOMMENDATION} | {RATIONALE} | [##{cop[:pr_id]}](#{cop[:pr_url]}) |"
+    end
+  else
+    puts "| Cop | #{column_name} | PR |"
+    puts "|-----|-------------|-----|"
+    cops.each do |cop|
+      desc = cop[:description].empty? ? "No description provided" : cop[:description]
+      puts "| `#{cop[:name]}` | #{desc} | [##{cop[:pr_id]}](#{cop[:pr_url]}) |"
+    end
+  end
+  puts ""
+end
+
+print_table("New cops", new_cops, "Description")
+print_table("Changed cops", changed_cops, "Change")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## Unreleased
+
+* Updates rubocop to [1.86.1](https://github.com/rubocop/rubocop/releases/tag/v1.86.1)
+* Updates standard-performance to [1.9.0](https://github.com/standardrb/standard-performance/releases/tag/v1.9.0)
 ## 1.54.0
 
 * Updates rubocop to [1.84.0](https://github.com/rubocop/rubocop/releases/tag/v1.84.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,16 +4,16 @@ PATH
     standard (1.54.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.84.0)
+      rubocop (~> 1.86.0)
       standard-custom (~> 1.0.0)
-      standard-performance (~> 1.8)
+      standard-performance (~> 1.9)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
     docile (1.4.0)
-    json (2.19.2)
+    json (2.19.5)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -21,8 +21,8 @@ GEM
       rake
     minitest (5.26.1)
     mutex_m (0.3.0)
-    parallel (1.27.0)
-    parser (3.3.10.0)
+    parallel (2.1.0)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     prism (1.9.0)
@@ -31,19 +31,19 @@ GEM
     rake (13.4.2)
     rbs (3.6.1)
       logger
-    regexp_parser (2.11.3)
-    rubocop (1.84.2)
+    regexp_parser (2.12.0)
+    rubocop (1.86.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      parallel (~> 1.10)
+      parallel (>= 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.0)
+    rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-performance (1.26.1)
@@ -86,4 +86,4 @@ DEPENDENCIES
   standard!
 
 BUNDLED WITH
-   2.5.23
+  4.0.11

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.add_dependency "rubocop", "~> 1.84.0"
+  spec.add_dependency "rubocop", "~> 1.86.0"
 
   spec.add_dependency "lint_roller", "~> 1.0"
   spec.add_dependency "standard-custom", "~> 1.0.0"
-  spec.add_dependency "standard-performance", "~> 1.8"
+  spec.add_dependency "standard-performance", "~> 1.9"
 
   # not semver: first three are lsp protocol version, last is patch
   spec.add_dependency "language_server-protocol", "~> 3.17.0.2"


### PR DESCRIPTION
Updates RuboCop from 1.84.0 to 1.86.1.
Updates standard-performance to 1.9.0.

## New cops

These cops were added and need a configuration decision before tests will pass:

| Cop | Description | Recommendation | Rationale | PR |
|-----|-------------|----------------|-----------|-----|
| `Lint/DataDefineOverride` | Checks for `Data.define` overriding existing methods. | Enable | Prevents subtle bugs in modern Ruby's `Data` objects by ensuring methods aren't accidentally shadowed. | [#14773](https://github.com/rubocop/rubocop/issues/14773) |
| `Lint/UnreachablePatternBranch` | Detects unreachable branches in `case` patterns. | Enable | This is a safety/lint rule that catches potential bugs in pattern matching, which is highly valuable for code quality. | [#14925](https://github.com/rubocop/rubocop/pull/14925) |
| `Style/EmptyClassDefinition` | Enforces consistent style for empty classes. | Enable | Promotes consistent coding style for empty classes, which aligns with Standard's goal of eliminating bikeshedding. | [#14961](https://github.com/rubocop/rubocop/issues/14961) |
| `Style/FileOpen` | Checks for `File.open` without a block. | Enable | Encourages safe resource management by ensuring files are closed, which is a strong safety improvement. | [#14942](https://github.com/rubocop/rubocop/pull/14942) |
| `Style/HashLookupMethod` | Enforces preference between `Hash#[]` and `Hash#fetch`. | Ignore | This is often a matter of context-specific preference (safety vs brevity) and enforcing one globally can cause high friction. | [#14977](https://github.com/rubocop/rubocop/issues/14977) |
| `Style/MapJoin` | Suggests more efficient alternatives to `map { ... }.join`. | Enable | Promotes more efficient and idiomatic Ruby patterns, which aligns with Standard's modernization goals. | [#14939](https://github.com/rubocop/rubocop/pull/14939) |
| `Style/OneClassPerFile` | Enforces one class per file. | Ignore | While generally good practice, it can be too restrictive for small utility classes or data structures, leading to excessive file proliferation. | [#14924](https://github.com/rubocop/rubocop/pull/14924) |
| `Style/PartitionInsteadOfDoubleSelect` | Suggests `partition` instead of two `select` calls. | Enable | Improves performance and readability by avoiding double iteration over collections. | [#14923](https://github.com/rubocop/rubocop/pull/14923) |
| `Style/PredicateWithKind` | Checks for predicate methods used with `kind_of?` or `is_a?`. | Enable | Encourages idiomatic predicate usage, improving code consistency and readability. | [#14811](https://github.com/rubocop/rubocop/pull/14811) |
| `Style/ReduceToHash` | Encourages `each_with_object` or `to_h` instead of `reduce`. | Enable | Encourages more readable and idiomatic alternatives for hash building. | [#14938](https://github.com/rubocop/rubocop/pull/14938) |
| `Style/RedundantMinMaxBy` | Detects redundant `min_by` or `max_by` calls. | Enable | Removes redundant code, aligning with the principle of simplicity. | [#14812](https://github.com/rubocop/rubocop/pull/14812) |
| `Style/RedundantStructKeywordInit` | Checks for redundant `keyword_init: true`. | Enable | Cleans up redundant configuration in modern Ruby where this might be the default or unnecessary. | [#13501](https://github.com/rubocop/rubocop/issues/13501) |
| `Style/SelectByKind` | Suggests `grep` instead of `select` with type check. | Enable | Encourages use of `grep`, which is a powerful and idiomatic Ruby feature for type-based filtering. | [#14808](https://github.com/rubocop/rubocop/pull/14808) |
| `Style/SelectByRange` | Suggests range slicing instead of `select`. | Enable | Promotes more concise and performant range-based collection access. | [#14810](https://github.com/rubocop/rubocop/pull/14810) |
| `Style/TallyMethod` | Enforces `Enumerable#tally`. | Enable | Encourages modern Ruby features (`tally`) for a very common pattern. | [#14922](https://github.com/rubocop/rubocop/pull/14922) |

## Changed cops

These existing cops had behavioral changes:

| Cop | Change | PR |
|-----|--------|-----|
| `Style/OneClassPerFile` | Now excludes `spec/**/*` and `test/**/*` by default. | [#15005](https://github.com/rubocop/rubocop/issues/15005) |
| `Style/RedundantStructKeywordInit` | Disabled by default. | [#15063](https://github.com/rubocop/rubocop/pull/15063) |
| `Lint/RedundantSafeNavigation` | Now aware of safe navigation in conditional true branch. | [#14989](https://github.com/rubocop/rubocop/pull/14989) |
| `Style/HashAsLastArrayItem` | Tweaked multiline autocorrection. | [#14872](https://github.com/rubocop/rubocop/pull/14872) |
| `Style/EndlessMethod` | Now considers receivers. | [#14917](https://github.com/rubocop/rubocop/pull/14917) |
| `Style/EmptyClassDefinition` | Renamed `class_definition` to `class_keyword` in `EnforcedStyle`. | [#14895](https://github.com/rubocop/rubocop/issues/14895) |
| `Style/RedundantInterpolationUnfreeze` | Added support for `String.new` with interpolated strings. | [#14956](https://github.com/rubocop/rubocop/pull/14956) |
| `Style/RedundantParentheses` | Now registers redundant parentheses around block bodies. | [#14955](https://github.com/rubocop/rubocop/pull/14955) |

---

The `config/` YAML files have not been updated for any of the above cops.
Tests are expected to fail until those configurations are added in a follow-up.
