### PR TITLE
Disable Style/RedundantStructKeywordInit

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1773,7 +1773,7 @@ Style/RedundantStringEscape:
   Enabled: true
 
 Style/RedundantStructKeywordInit:
-  Enabled: true
+  Enabled: false
 
 Style/RegexpLiteral:
   Enabled: false

--- a/config/ruby-3.1.yml
+++ b/config/ruby-3.1.yml
@@ -9,6 +9,3 @@ Style/DataInheritance:
 Style/ArgumentsForwarding:
   Enabled: false
   AllowOnlyRestArgument: true
-
-Style/RedundantStructKeywordInit:
-  Enabled: false


### PR DESCRIPTION
Closes #814.

Disables Style/RedundantStructKeywordInit in Standard's base config because `keyword_init: true` is often not redundant.

Also removes the now-redundant Ruby 3.1 override.