### PR TITLE
Allow Steep annotation

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -250,6 +250,7 @@ Layout/InitialIndentation:
 Layout/LeadingCommentSpace:
   Enabled: true
   AllowRBSInlineAnnotation: true
+  AllowSteepAnnotation: true
 
 Layout/LeadingEmptyLines:
   Enabled: true


### PR DESCRIPTION
## Summary

#709 added `AllowRBSInlineAnnotation` to `Layout/LeadingCommentSpace` so RBS inline type annotations (`#: ...`) aren't flagged. This PR follows that same precedent for [Steep](https://github.com/soutaro/steep)'s equivalent inline annotation syntax (`#: ...`, `#$ ...`), by turning on RuboCop's `AllowSteepAnnotation` option for the same cop.
